### PR TITLE
Worker Group Selector on Dashboards

### DIFF
--- a/criblvision/default/data/ui/views/auditlogs.xml
+++ b/criblvision/default/data/ui/views/auditlogs.xml
@@ -1,7 +1,7 @@
 <form theme="dark" script="button_click.js" version="1.1">
   <label>Cribl Leader Audit Logs</label>
   <fieldset submitButton="true" autoRun="true">
-    <input type="time" token="time" searchWhenChanged="false">
+    <input type="time" token="time" searchWhenChanged="true">
       <label>Timerange</label>
       <default>
         <earliest>-15m</earliest>
@@ -13,7 +13,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index` AND source IN ("*/audit.log", "*/audit1.log", "*/audit2.log", "*/audit3.log", "*/audit4.log")
+        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index` source IN ("*/audit.log", "*/audit1.log", "*/audit2.log", "*/audit3.log", "*/audit4.log") NOT [| inputlookup cribl_stream_workers | rename worker AS host | table host ]
 | mvexpand host
 | sort host</query>
         <earliest>$time.earliest$</earliest>

--- a/criblvision/default/data/ui/views/commit_and_deploy_audit_logs.xml
+++ b/criblvision/default/data/ui/views/commit_and_deploy_audit_logs.xml
@@ -1,7 +1,7 @@
 <form theme="dark" script="button_click.js" version="1.1">
   <label>Commit and Deploy Audit Logs</label>
   <fieldset submitButton="true" autoRun="false">
-    <input type="time" token="time" searchWhenChanged="false">
+    <input type="time" token="time" searchWhenChanged="true">
       <label>Timerange</label>
       <default>
         <earliest>-15m</earliest>
@@ -13,7 +13,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index` AND source IN ("*/audit.log", "*/audit1.log", "*/audit2.log", "*/audit3.log", "*/audit4.log")
+        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index` source IN ("*/audit.log", "*/audit1.log", "*/audit2.log", "*/audit3.log", "*/audit4.log") NOT [| inputlookup cribl_stream_workers | rename worker AS host | table host ]
 | mvexpand host
 | sort host</query>
         <earliest>$time.earliest$</earliest>

--- a/criblvision/default/data/ui/views/cribl_thruput_introspection.xml
+++ b/criblvision/default/data/ui/views/cribl_thruput_introspection.xml
@@ -2,25 +2,37 @@
   <label>Cribl Thruput Introspection</label>
   <description>Cribl Thruput Introspection</description>
   <fieldset submitButton="true" autoRun="false">
-    <input type="time" searchWhenChanged="false" token="global_time_tok">
+    <input type="time" searchWhenChanged="true" token="global_time_tok">
       <label>Time Range</label>
       <default>
         <earliest>-15m</earliest>
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="worker_group">
+      <label>Worker Group</label>
+      <choice value="*">All Worker Groups</choice>
+      <initialValue>*</initialValue>
+      <fieldForLabel>worker_group</fieldForLabel>
+      <fieldForValue>worker_group</fieldForValue>
+      <search>
+        <query>| inputlookup cribl_stream_workers | stats count BY worker_group</query>
+        <earliest>-24h@h</earliest>
+        <latest>now</latest>
+      </search>
+    </input>
     <input type="dropdown" token="host">
       <label>Host</label>
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host</query>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
-      <choice value="*">All</choice>
-      <prefix>"</prefix>
-      <suffix>"</suffix>
+      <choice value="*">All Hosts</choice>
+      <default>*</default>
+      <initialValue>*</initialValue>
     </input>
     <input type="dropdown" token="mstats_span" searchWhenChanged="true">
       <label>Time Span</label>
@@ -75,7 +87,7 @@
         <fieldForLabel>output</fieldForLabel>
         <fieldForValue>output</fieldForValue>
         <search>
-          <query>| mstats avg(`set_cribl_metrics_prefix("total.out_events")`) WHERE `set_cribl_metrics_index` BY output
+          <query>| mstats avg(`set_cribl_metrics_prefix("total.out_events")`) WHERE `set_cribl_metrics_index` group=$worker_group$ BY output
 | table output</query>
           <earliest>$global_time_tok.earliest$</earliest>
           <latest>$global_time_tok.latest$</latest>
@@ -84,7 +96,7 @@
       <chart>
         <title>Total events out</title>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("total.out_events")`) AS out_events WHERE `set_cribl_metrics_index` AND "host"=$host$ AND $output_token$ $mstats_span$ BY output
+          <query>| mstats sum(`set_cribl_metrics_prefix("total.out_events")`) AS out_events WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$ $output_token$ $mstats_span$ BY output
 | timechart sum("out_events") $timechart_span$ useother=false BY output WHERE max in top5
 | fields - _span*</query>
           <earliest>$global_time_tok.earliest$</earliest>
@@ -102,7 +114,7 @@
       <chart>
         <title>Total bytes outs</title>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("total.out_bytes")`) AS out_bytes  WHERE `set_cribl_metrics_index` AND "host"=$host$ AND $output_token$ $mstats_span$ BY output
+          <query>| mstats sum(`set_cribl_metrics_prefix("total.out_bytes")`) AS out_bytes  WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$ $output_token$ $mstats_span$ BY output
 | timechart sum("out_bytes") $timechart_span$ useother=false BY output WHERE max in top5
 | fields - _span*</query>
           <earliest>$global_time_tok.earliest$</earliest>
@@ -133,7 +145,7 @@
         <fieldForLabel>input</fieldForLabel>
         <fieldForValue>input</fieldForValue>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("total.in_events")`) WHERE `set_cribl_metrics_index` BY input</query>
+          <query>| mstats sum(`set_cribl_metrics_prefix("total.in_events")`) WHERE `set_cribl_metrics_index` group=$worker_group$ BY input</query>
           <earliest>-24h@h</earliest>
           <latest>now</latest>
         </search>
@@ -173,7 +185,7 @@
       <chart>
         <title>Total events in</title>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("total.in_events")`) AS in_events  WHERE `set_cribl_metrics_index` AND $input_token$ $mstats_span$ BY $splitby$
+          <query>| mstats sum(`set_cribl_metrics_prefix("total.in_events")`) AS in_events  WHERE `set_cribl_metrics_index` group=$worker_group$ $input_token$ $mstats_span$ BY $splitby$
 | timechart sum("in_events") $timechart_span$ useother=false BY $splitby$ WHERE max in top$limit$
 | fields - _span*</query>
           <earliest>$global_time_tok.earliest$</earliest>
@@ -192,8 +204,8 @@
       <chart depends="$show_cpu_chart$">
         <title>Cpu Percentage by Worker Process</title>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("system.cpu_perc")`) AS cpu_perc  WHERE `set_cribl_metrics_index` $mstats_span$ BY $splitby$
-| timechart last("cpu_perc") $timechart_span$ useother=false BY $splitby$ WHERE max in top$limit$
+          <query>| mstats sum(`set_cribl_metrics_prefix("system.cpu_perc")`) AS cpu_perc WHERE `set_cribl_metrics_index` group=$worker_group$ $mstats_span$ BY $splitby$
+| timechart sum("cpu_perc") $timechart_span$ useother=false BY $splitby$ WHERE max in top$limit$
 | fields - _span*</query>
           <earliest>$global_time_tok.earliest$</earliest>
           <latest>$global_time_tok.latest$</latest>
@@ -211,7 +223,7 @@
       <chart>
         <title>Total bytes in</title>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("total.in_bytes")`) AS in_bytes  WHERE `set_cribl_metrics_index` AND $input_token$ $mstats_span$ BY $splitby$
+          <query>| mstats sum(`set_cribl_metrics_prefix("total.in_bytes")`) AS in_bytes  WHERE `set_cribl_metrics_index` group=$worker_group$ $input_token$ $mstats_span$ BY $splitby$
 | timechart sum("in_bytes") $timechart_span$ useother=false BY $splitby$ WHERE max in top$limit$
 | fields - _span*</query>
           <earliest>$global_time_tok.earliest$</earliest>

--- a/criblvision/default/data/ui/views/destinations_overview.xml
+++ b/criblvision/default/data/ui/views/destinations_overview.xml
@@ -1,27 +1,8 @@
 <form theme="dark" script="button_click.js" version="1.1">
   <label>Destinations Overview</label>
-  <fieldset submitButton="true" autoRun="false">
-    <input type="time" token="field1" searchWhenChanged="false">
-      <label>Timerange</label>
-      <default>
-        <earliest>-15m</earliest>
-        <latest>now</latest>
-      </default>
-    </input>
-    <input type="dropdown" token="host">
-      <label>Host</label>
-      <fieldForLabel>host</fieldForLabel>
-      <fieldForValue>host</fieldForValue>
-      <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host</query>
-        <earliest>-24h@h</earliest>
-        <latest>now</latest>
-      </search>
-      <choice value="*">All</choice>
-    </input>
-  </fieldset>
-  <row>
+      <row>
     <panel>
+      
       <html rejects="$show_details$">
         <button id="showButton" class="btn">How to Use</button>
       </html>
@@ -35,12 +16,46 @@
       </html>
     </panel>
   </row>
+  <fieldset submitButton="true" autoRun="false">
+    <input type="time" token="field1" searchWhenChanged="true">
+      <label>Timerange</label>
+      <default>
+        <earliest>-15m</earliest>
+        <latest>now</latest>
+      </default>
+    </input>
+    <input type="dropdown" token="worker_group">
+      <label>Worker Group</label>
+      <choice value="*">All Worker Groups</choice>
+      <initialValue>*</initialValue>
+      <fieldForLabel>worker_group</fieldForLabel>
+      <fieldForValue>worker_group</fieldForValue>
+      <search>
+        <query>| inputlookup cribl_stream_workers | stats count BY worker_group</query>
+        <earliest>-24h@h</earliest>
+        <latest>now</latest>
+      </search>
+    </input>
+    <input type="dropdown" token="host">
+      <label>Host</label>
+      <fieldForLabel>host</fieldForLabel>
+      <fieldForValue>host</fieldForValue>
+      <search>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
+        <earliest>-24h@h</earliest>
+        <latest>now</latest>
+      </search>
+      <choice value="*">All Hosts</choice>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
+  </fieldset>
   <row>
     <panel>
       <title>% Error Messages Across All Destinations</title>
       <single>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ cid=* channel=output* | stats count AS "Total", count(eval(match(level,"error"))) AS errorcount | eval error_percentage=(errorcount/Total)*100| table error_percentage</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ cid=* channel=output* | stats count AS "Total", count(eval(match(level,"error"))) AS errorcount | eval error_percentage=(errorcount/Total)*100| table error_percentage</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -60,7 +75,7 @@
         <option name="trendColorInterpretation">standard</option>
         <option name="trendDisplayMode">absolute</option>
         <option name="unit">%</option>
-        <option name="unitPosition">after</option>
+        <option name="unitPosition">before</option>
         <option name="useColors">0</option>
         <option name="useThousandSeparators">1</option>
       </single>
@@ -69,7 +84,7 @@
       <title>% of Warn messages across all Destinations</title>
       <single>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ cid=* channel=output* | stats count AS "Total", count(eval(match(level,"warn"))) AS warncount | eval warn_percentage=(warncount/Total)*100| table warn_percentage</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ cid=* channel=output* | stats count AS "Total", count(eval(match(level,"warn"))) AS warncount | eval warn_percentage=(warncount/Total)*100| table warn_percentage</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -89,7 +104,7 @@
         <option name="trendColorInterpretation">standard</option>
         <option name="trendDisplayMode">absolute</option>
         <option name="unit">%</option>
-        <option name="unitPosition">after</option>
+        <option name="unitPosition">before</option>
         <option name="useColors">0</option>
         <option name="useThousandSeparators">1</option>
       </single>
@@ -98,7 +113,7 @@
       <title>%of info messages across all Destinations</title>
       <single>
         <search>
-          <query>`set_cribl_internal_log_index` cid=* host=$host$ channel=output* | stats count AS "Total", count(eval(match(level,"info"))) AS infocount | eval info_percentage=(infocount/Total)*100| table info_percentage</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ cid=* channel=output* | stats count AS "Total", count(eval(match(level,"info"))) AS infocount | eval info_percentage=(infocount/Total)*100| table info_percentage</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -118,7 +133,7 @@
         <option name="trendColorInterpretation">standard</option>
         <option name="trendDisplayMode">absolute</option>
         <option name="unit">%</option>
-        <option name="unitPosition">after</option>
+        <option name="unitPosition">before</option>
         <option name="useColors">0</option>
         <option name="useThousandSeparators">1</option>
       </single>
@@ -136,7 +151,7 @@
       </input>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ cid=* channel=output* | stats count AS "Total", count(eval(match(level,"$loglevel1$"))) AS $loglevel1$count by channel | eval $loglevel1$_percentage=($loglevel1$count/Total)*100| eval $loglevel1$_percentage=round($loglevel1$_percentage,2) 
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ cid=* channel=output* | stats count AS "Total", count(eval(match(level,"$loglevel1$"))) AS $loglevel1$count by channel | eval $loglevel1$_percentage=($loglevel1$count/Total)*100| eval $loglevel1$_percentage=round($loglevel1$_percentage,2) 
 | table $loglevel1$_percentage channel 
 | sort -error_percentage</query>
           <earliest>$field1.earliest$</earliest>

--- a/criblvision/default/data/ui/views/health_check.xml
+++ b/criblvision/default/data/ui/views/health_check.xml
@@ -8,6 +8,18 @@
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="worker_group">
+      <label>Worker Group</label>
+      <choice value="*">All Worker Groups</choice>
+      <initialValue>*</initialValue>
+      <fieldForLabel>worker_group</fieldForLabel>
+      <fieldForValue>worker_group</fieldForValue>
+      <search>
+        <query>| inputlookup cribl_stream_workers | stats count BY worker_group</query>
+        <earliest>-24h@h</earliest>
+        <latest>now</latest>
+      </search>
+    </input>
     <input type="dropdown" token="host">
       <label>Host</label>
       <fieldForLabel>host</fieldForLabel>

--- a/criblvision/default/data/ui/views/health_check.xml
+++ b/criblvision/default/data/ui/views/health_check.xml
@@ -25,7 +25,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host</query>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
@@ -52,7 +52,7 @@
       <title>CPU Perc (Avg)</title>
       <single>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ channel=server message="_raw stats" | stats avg(cpuPerc) as cpuPerc</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | stats avg(cpuPerc) as cpuPerc</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -80,7 +80,7 @@
       <title>Memory Usage (avg)</title>
       <single>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ channel=server message="_raw stats" | stats avg(mem.rss) as memRss</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | stats avg(mem.rss) as memRss</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -111,7 +111,7 @@
       <title>Unhealthy Sources</title>
       <single>
         <search>
-          <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS Status prestats=true WHERE `set_cribl_metrics_index` AND "host"=$host$ span=30s BY input
+          <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS Status prestats=true WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$ span=30s BY input
 | stats max(Status) as Status BY input
 | eval Status=round(Status, 0)
 | where Status!=0
@@ -130,7 +130,7 @@
       <title>Unhealthy Destinations</title>
       <single>
         <search>
-          <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS Status prestats=true WHERE `set_cribl_metrics_index` AND "host"=$host$ span=30s BY output
+          <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS Status prestats=true WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$ span=30s BY output
 | stats max(Status)  as Status BY output
 | eval Status=round(Status, 0)
 | where Status!=0
@@ -148,7 +148,7 @@
       <title>Cluster Communication Errors</title>
       <single>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ channel=clustercomm level=warn OR level=error NOT message=metric*
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=clustercomm level=warn OR level=error NOT message=metric*
 | stats count 
 | rename count as "cluster communication errors"</query>
           <earliest>$field1.earliest$</earliest>
@@ -163,7 +163,7 @@
       <title>Current Total PQ size (bytes)</title>
       <single>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) as total_pq_size WHERE `set_cribl_metrics_index` AND "host"=$host$</query>
+          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) as total_pq_size WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -193,7 +193,7 @@
       <title>Worker Process Restarts</title>
       <single>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ channel=cribl* message="restarting worker process" 
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=cribl* message="restarting worker process" 
 | stats count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
@@ -222,7 +222,7 @@
       <title>Destinations with Backpressure</title>
       <single>
         <search>
-          <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) as back_pressured WHERE `set_cribl_metrics_index` AND "host"=$host$ BY output
+          <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) as back_pressured WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$ BY output
 | search back_pressured &gt; 0
 | stats count</query>
           <earliest>$field1.earliest$</earliest>
@@ -236,7 +236,7 @@
       <title>Blocked Destinations</title>
       <single>
         <search>
-          <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) as back_pressured WHERE `set_cribl_metrics_index` AND "host"=$host$ BY output
+          <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) as back_pressured WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$ BY output
 | search back_pressured &gt; 0
 | stats count</query>
           <earliest>$field1.earliest$</earliest>
@@ -250,7 +250,7 @@
       <title>Destinations with PQ engaged</title>
       <single>
         <search>
-          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) as pq_engaged WHERE `set_cribl_metrics_index` AND "host"=$host$ BY output
+          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) as pq_engaged WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$ BY output
 | search pq_engaged &gt; 0
 | stats count</query>
           <earliest>$field1.earliest$</earliest>

--- a/criblvision/default/data/ui/views/health_check.xml
+++ b/criblvision/default/data/ui/views/health_check.xml
@@ -29,7 +29,9 @@
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
-      <choice value="*">All</choice>
+      <choice value="*">All Hosts</choice>
+      <default>*</default>
+      <initialValue>*</initialValue>
     </input>
   </fieldset>
   <row>

--- a/criblvision/default/data/ui/views/home.xml
+++ b/criblvision/default/data/ui/views/home.xml
@@ -1,23 +1,37 @@
 <form theme="dark" script="button_click.js" version="1.1">
   <label>Log Analytics</label>
   <fieldset submitButton="true" autoRun="false">
-    <input type="time" token="field1" searchWhenChanged="false">
+    <input type="time" token="field1" searchWhenChanged="true">
       <label>Timerange</label>
       <default>
         <earliest>-15m</earliest>
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="worker_group">
+      <label>Worker Group</label>
+      <choice value="*">All Worker Groups</choice>
+      <initialValue>*</initialValue>
+      <fieldForLabel>worker_group</fieldForLabel>
+      <fieldForValue>worker_group</fieldForValue>
+      <search>
+        <query>| inputlookup cribl_stream_workers | stats count BY worker_group</query>
+        <earliest>-24h@h</earliest>
+        <latest>now</latest>
+      </search>
+    </input>
     <input type="dropdown" token="host">
       <label>Host</label>
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host</query>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
-      <choice value="*">All</choice>
+      <choice value="*">All Hosts</choice>
+      <default>*</default>
+      <initialValue>*</initialValue>
     </input>
     <input type="dropdown" token="debug">
       <label>Show Debug?</label>
@@ -75,7 +89,7 @@
       </input>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ level=ERROR cid=$logtype$ | chart count sparkline by $messagesplit$ | sort -count</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ level=ERROR cid=$logtype$ | chart count sparkline by $messagesplit$ | sort -count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -111,7 +125,7 @@
       </input>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ level=WARN cid=$logtype1$ | chart count sparkline by $messagesplit1$ | sort -count</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ level=WARN cid=$logtype1$ | chart count sparkline by $messagesplit1$ | sort -count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -145,7 +159,7 @@
       </input>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ level=INFO cid=$logtype2$ | chart count sparkline by $messagesplit2$ | sort -count</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ level=INFO cid=$logtype2$ | chart count sparkline by $messagesplit2$ | sort -count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -179,7 +193,7 @@
       </input>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index`  host=$host$ level=DEBUG cid=$logtype3$ | chart count sparkline by $messagesplit3$ | sort -count</query>
+          <query>`set_cribl_internal_log_index`  host=$host$ worker_group=$worker_group$ level=DEBUG cid=$logtype3$ | chart count sparkline by $messagesplit3$ | sort -count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -200,14 +214,14 @@
     <panel>
       <event>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ $name$=$value|s$ level=$level$</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ $name$=$value|s$ level=$level$</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
         <option name="list.drilldown">full</option>
         <option name="refresh.display">progressbar</option>
         <drilldown>
-          <link target="_blank">search?q=%60set_cribl_internal_log_index%60%20%20source%3D*.log%20$name$%3D$value|s$%20level%3D$level$&amp;earliest=$field1.earliest$&amp;latest=$field1.latest$</link>
+          <link target="_blank">search?q=%60set_cribl_internal_log_index%60%20source%3D*.log%20$name$%3D$value|s$%20level%3D$level$&amp;earliest=$field1.earliest$&amp;latest=$field1.latest$</link>
         </drilldown>
       </event>
     </panel>

--- a/criblvision/default/data/ui/views/leader_performance_introspection.xml
+++ b/criblvision/default/data/ui/views/leader_performance_introspection.xml
@@ -1,7 +1,7 @@
 <form theme="dark" script="button_click.js" version="1.1">
   <label>Leader Performance Introspection</label>
   <fieldset submitButton="true" autoRun="false">
-    <input type="time" token="field1" searchWhenChanged="false">
+    <input type="time" token="field1" searchWhenChanged="true">
       <label>Timerange</label>
       <default>
         <earliest>-60m@m</earliest>
@@ -13,7 +13,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host</query>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` NOT [| inputlookup cribl_stream_workers | rename worker AS host | table host ] | mvexpand host | sort host</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>

--- a/criblvision/default/data/ui/views/persistent_queue_analytics.xml
+++ b/criblvision/default/data/ui/views/persistent_queue_analytics.xml
@@ -1,23 +1,37 @@
 <form theme="dark" script="button_click.js" version="1.1">
   <label>Persistent Queue Analytics</label>
   <fieldset submitButton="true" autoRun="false">
-    <input type="time" token="field1" searchWhenChanged="false">
+    <input type="time" token="field1" searchWhenChanged="true">
       <label>Timerange</label>
       <default>
         <earliest>-60m@m</earliest>
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="worker_group">
+      <label>Worker Group</label>
+      <choice value="*">All Worker Groups</choice>
+      <initialValue>*</initialValue>
+      <fieldForLabel>worker_group</fieldForLabel>
+      <fieldForValue>worker_group</fieldForValue>
+      <search>
+        <query>| inputlookup cribl_stream_workers | stats count BY worker_group</query>
+        <earliest>-24h@h</earliest>
+        <latest>now</latest>
+      </search>
+    </input>
     <input type="dropdown" token="host">
       <label>Host</label>
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host</query>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
-      <choice value="*">All</choice>
+      <choice value="*">All Hosts</choice>
+      <default>*</default>
+      <initialValue>*</initialValue>
     </input>
   </fieldset>
   <row>
@@ -40,11 +54,11 @@
       <title>Count of Destinations with PQ engaged</title>
       <single>
         <search>
-          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) as pq_engaged WHERE `set_cribl_metrics_index` AND "host"=$host$ BY output
+          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) as pq_engaged WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$ BY output
 | search pq_engaged &gt; 0
 | stats count</query>
-          <earliest>$field1.earliest$</earliest>
-          <latest>$field1.latest$</latest>
+          <earliest>-24h@h</earliest>
+          <latest>now</latest>
           <sampleRatio>1</sampleRatio>
         </search>
         <option name="colorBy">value</option>
@@ -70,9 +84,9 @@
       <title>Current PQ size</title>
       <single>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) as total_pq_size WHERE `set_cribl_metrics_index` AND "host"=$host$</query>
-          <earliest>$field1.earliest$</earliest>
-          <latest>$field1.latest$</latest>
+          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) as total_pq_size WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$</query>
+          <earliest>-24h@h</earliest>
+          <latest>now</latest>
           <sampleRatio>1</sampleRatio>
         </search>
         <option name="colorBy">value</option>
@@ -98,11 +112,11 @@
       <title>Outputs with pq engaged</title>
       <table>
         <search>
-          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) as pq_engaged WHERE `set_cribl_metrics_index` AND "host"=$host$ BY output
+          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) as pq_engaged WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$ BY output
 | search pq_engaged &gt; 0 
 | stats values(output) as "outputs with pq engaged"</query>
-          <earliest>$field1.earliest$</earliest>
-          <latest>$field1.latest$</latest>
+          <earliest>-24h@h</earliest>
+          <latest>now</latest>
           <sampleRatio>1</sampleRatio>
         </search>
         <option name="count">20</option>
@@ -121,11 +135,11 @@
       <title>PQ size by destination</title>
       <chart>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS ps_size WHERE `set_cribl_metrics_index` AND "host"=$host$ span=10s BY output
+          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS ps_size WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$ span=10s BY output
 | timechart sum("pq_size") span=10s useother=false BY output WHERE max in top100
 | fields - _span*</query>
-          <earliest>$field1.earliest$</earliest>
-          <latest>$field1.latest$</latest>
+          <earliest>-24h@h</earliest>
+          <latest>now</latest>
           <sampleRatio>1</sampleRatio>
         </search>
         <option name="charting.axisLabelsX.majorLabelStyle.overflowMode">ellipsisNone</option>
@@ -173,7 +187,7 @@
       </input>
       <event>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ channel="IPersistentQueue"</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel="IPersistentQueue"</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
           <sampleRatio>1</sampleRatio>

--- a/criblvision/default/data/ui/views/sizingcalculator.xml
+++ b/criblvision/default/data/ui/views/sizingcalculator.xml
@@ -25,11 +25,11 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index()`| mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
         <earliest>0</earliest>
-        <latest></latest>
+        <latest>now</latest>
       </search>
-      <choice value="*">All Workers</choice>
+      <choice value="*">All Hosts</choice>
       <default>*</default>
       <initialValue>*</initialValue>
     </input>

--- a/criblvision/default/data/ui/views/sizingcalculator.xml
+++ b/criblvision/default/data/ui/views/sizingcalculator.xml
@@ -8,15 +8,30 @@
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="worker_group">
+      <label>Worker Group</label>
+      <choice value="*">All Worker Groups</choice>
+      <initialValue>*</initialValue>
+      <fieldForLabel>worker_group</fieldForLabel>
+      <fieldForValue>worker_group</fieldForValue>
+      <search>
+        <query>| inputlookup cribl_stream_workers | stats count BY worker_group</query>
+        <earliest>-24h@h</earliest>
+        <latest>now</latest>
+      </search>
+    </input>
     <input type="dropdown" token="host">
       <label>Host</label>
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index()`| mvexpand host</query>
+        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index()`| mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
         <earliest>0</earliest>
         <latest></latest>
       </search>
+      <choice value="*">All Workers</choice>
+      <default>*</default>
+      <initialValue>*</initialValue>
     </input>
     <input type="dropdown" token="cpuSpeed">
       <label>CPU Speed</label>
@@ -47,11 +62,12 @@
       <choice value="3.9">3.9GHz</choice>
       <default>3.0</default>
     </input>
-    <input type="radio" token="cpuType" searchWhenChanged="false">
+    <input type="radio" token="cpuType" searchWhenChanged="true">
       <label>CPU Architecture</label>
       <choice value="200">x64 (Hyperthreading)</choice>
       <choice value="400">x64</choice>
       <choice value="480">ARM64</choice>
+      <default>200</default>
     </input>
   </fieldset>
   <row>
@@ -94,8 +110,9 @@
           <done>
             <set token="workerProcessCount">$result.WorkerProcessCount$</set>
           </done>
-          <query>`set_cribl_internal_log_index()` `set_cribl_log_sourcetype()` host=$host$ channel="server" message="_raw stats"
-| stats dc(cid) AS WorkerProcessCount</query>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` host=$host$ worker_group=$worker_group$ channel="server" message="_raw stats"
+| stats dc(cid) AS WorkerProcessCount BY host
+| stats sum(WorkerProcessCount) AS WorkerProcessCount</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
@@ -142,7 +159,7 @@
       <title>Total Throughput (inBytes + outBytes) in GB</title>
       <chart>
         <search>
-          <query>`set_cribl_internal_log_index()` `set_cribl_log_sourcetype()` host=$host$ AND channel="server" AND message="_raw stats"
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` host=$host$ worker_group=$worker_group$ channel="server" message="_raw stats"
 | bin span=1d _time
 | stats sum(inBytes) AS inBytes sum(outBytes) AS outBytes by _time
 | eval totalGB=round((('inBytes' + 'outBytes') / 1024 / 1024 / 1024), 0)
@@ -159,12 +176,12 @@
       <title>Estimated Worker Processes Required</title>
       <chart>
         <search>
-          <query>`set_cribl_internal_log_index()` `set_cribl_log_sourcetype()` host=$host$ AND channel="server" AND message="_raw stats"
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` host=$host$ worker_group=$worker_group$ channel="server" message="_raw stats"
 | bin span=1d _time
 | stats sum(inBytes) AS inBytes sum(outBytes) AS outBytes by _time
-| eval inTB=round(('inBytes' / 1024 / 1024 / 1024 / 1024), 0)
-| eval outTB=round(('outBytes' / 1024 / 1024 / 1024 / 1024), 0)
-| eval calculation=(round(((('inTB' + 'outTB') * 1024) / $processingLimitPerCPU$), 0) + 1)
+| eval inGB=round(('inBytes' / 1024 / 1024 / 1024), 0)
+| eval outGB=round(('outBytes' / 1024 / 1024 / 1024), 0)
+| eval calculation=(round(((('inGB' + 'outGB') * 1024) / $processingLimitPerCPU$), 0) + 1)
 | timechart span=1d max(calculation) AS "Estimated Worker Processes Required"</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -180,7 +197,7 @@
       <title>Estimated Worker Processes Required, based on DAILY throughput over the given TimeRange</title>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index()` `set_cribl_log_sourcetype()` host=$host$ AND channel="server" AND message="_raw stats"
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` host=$host$ worker_group=$worker_group$ channel="server" message="_raw stats"
 | bin span=1d _time
 | stats sum(inBytes) AS inBytes sum(outBytes) AS outBytes by _time
 | eval inGB=round(('inBytes' / 1024 / 1024 / 1024), 0)
@@ -201,7 +218,7 @@
       <title>Percentage, over the provided timerange, that a Worker Process exceeded 90% cpuPerc usage</title>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index()` `set_cribl_log_sourcetype()` host=$host$ AND channel="server" AND message="_raw stats"
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` host=$host$ worker_group=$worker_group$ channel="server" message="_raw stats"
 | bin span=1m _time
 | stats max(cpuPerc) AS cpuPerc by _time cid
 | eval Percentage=if(cpuPerc &gt;= 90, 1, 0)
@@ -224,7 +241,7 @@
       <title>Percentage, over the provided timerange, that a Worker Process exceeded 90% eluPerc usage</title>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index()` `set_cribl_log_sourcetype()` host=$host$ AND channel="server" AND message="_raw stats"
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` host=$host$ worker_group=$worker_group$ channel="server" message="_raw stats"
 | bin span=1m _time
 | stats max(eluPerc) AS eluPerc by _time cid
 | eval Percentage=if(eluPerc &gt;= 90, 1, 0)

--- a/criblvision/default/data/ui/views/sources_overview.xml
+++ b/criblvision/default/data/ui/views/sources_overview.xml
@@ -1,28 +1,8 @@
 <form theme="dark" script="button_click.js" version="1.1">
   <label>Sources Overview</label>
-  <fieldset submitButton="true" autoRun="false">
-    <input type="time" token="field1" searchWhenChanged="false">
-      <label>Timerange</label>
-      <default>
-        <earliest>-15m</earliest>
-        <latest>now</latest>
-      </default>
-    </input>
-    <input type="dropdown" token="host">
-      <label>Host</label>
-      <fieldForLabel>host</fieldForLabel>
-      <fieldForValue>host</fieldForValue>
-      <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host</query>
-        <earliest>-24h@h</earliest>
-        <latest>now</latest>
-      </search>
-      <choice value="*">All</choice>
-      <initialValue>*</initialValue>
-    </input>
-  </fieldset>
-  <row>
+      <row>
     <panel>
+      
       <html rejects="$show_details$">
         <button id="showButton" class="btn">How to Use</button>
       </html>
@@ -36,12 +16,46 @@
       </html>
     </panel>
   </row>
+  <fieldset submitButton="true" autoRun="false">
+    <input type="time" token="field1" searchWhenChanged="true">
+      <label>Timerange</label>
+      <default>
+        <earliest>-15m</earliest>
+        <latest>now</latest>
+      </default>
+    </input>
+    <input type="dropdown" token="worker_group">
+      <label>Worker Group</label>
+      <choice value="*">All Worker Groups</choice>
+      <initialValue>*</initialValue>
+      <fieldForLabel>worker_group</fieldForLabel>
+      <fieldForValue>worker_group</fieldForValue>
+      <search>
+        <query>| inputlookup cribl_stream_workers | stats count BY worker_group</query>
+        <earliest>-24h@h</earliest>
+        <latest>now</latest>
+      </search>
+    </input>
+    <input type="dropdown" token="host">
+      <label>Host</label>
+      <fieldForLabel>host</fieldForLabel>
+      <fieldForValue>host</fieldForValue>
+      <search>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
+        <earliest>-24h@h</earliest>
+        <latest>now</latest>
+      </search>
+      <choice value="*">All Hosts</choice>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
+  </fieldset>
   <row>
     <panel>
       <title>% Error Messages Across All Sources</title>
       <single>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ cid=* channel=input* | stats count AS "Total", count(eval(match(level,"error"))) AS errorcount | eval error_percentage=(errorcount/Total)*100| table error_percentage</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ cid=* channel=input* | stats count AS "Total", count(eval(match(level,"error"))) AS errorcount | eval error_percentage=(errorcount/Total)*100| table error_percentage</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -61,7 +75,7 @@
         <option name="trendColorInterpretation">standard</option>
         <option name="trendDisplayMode">absolute</option>
         <option name="unit">%</option>
-        <option name="unitPosition">after</option>
+        <option name="unitPosition">before</option>
         <option name="useColors">0</option>
         <option name="useThousandSeparators">1</option>
       </single>
@@ -70,7 +84,7 @@
       <title>% of Warn messages across all sources</title>
       <single>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ cid=* channel=input* | stats count AS "Total", count(eval(match(level,"warn"))) AS warncount | eval warn_percentage=(warncount/Total)*100| table warn_percentage</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ cid=* channel=input* | stats count AS "Total", count(eval(match(level,"warn"))) AS warncount | eval warn_percentage=(warncount/Total)*100| table warn_percentage</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -90,7 +104,7 @@
         <option name="trendColorInterpretation">standard</option>
         <option name="trendDisplayMode">absolute</option>
         <option name="unit">%</option>
-        <option name="unitPosition">after</option>
+        <option name="unitPosition">before</option>
         <option name="useColors">0</option>
         <option name="useThousandSeparators">1</option>
       </single>
@@ -99,7 +113,7 @@
       <title>%of info messages across all sources</title>
       <single>
         <search>
-          <query>`set_cribl_internal_log_index` cid=* host=$host$ channel=input* | stats count AS "Total", count(eval(match(level,"info"))) AS infocount | eval info_percentage=(infocount/Total)*100| table info_percentage</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ cid=* channel=input* | stats count AS "Total", count(eval(match(level,"info"))) AS infocount | eval info_percentage=(infocount/Total)*100| table info_percentage</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -119,7 +133,7 @@
         <option name="trendColorInterpretation">standard</option>
         <option name="trendDisplayMode">absolute</option>
         <option name="unit">%</option>
-        <option name="unitPosition">after</option>
+        <option name="unitPosition">before</option>
         <option name="useColors">0</option>
         <option name="useThousandSeparators">1</option>
       </single>
@@ -128,7 +142,7 @@
   <row>
     <panel>
       <title>$loglevel1$ log level percentage counts by channel</title>
-      <input type="dropdown" token="loglevel1" searchWhenChanged="true">
+      <input type="dropdown" token="loglevel1">
         <label>Log Level</label>
         <choice value="error">Error</choice>
         <choice value="warn">Warn</choice>
@@ -137,7 +151,7 @@
       </input>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ cid=* channel=input* | stats count AS "Total", count(eval(match(level,"$loglevel1$"))) AS $loglevel1$count by channel | eval $loglevel1$_percentage=($loglevel1$count/Total)*100| table $loglevel1$_percentage channel 
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ cid=* channel=input* | stats count AS "Total", count(eval(match(level,"$loglevel1$"))) AS $loglevel1$count by channel | eval $loglevel1$_percentage=($loglevel1$count/Total)*100| table $loglevel1$_percentage channel 
 | sort -error_percentage</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
@@ -164,7 +178,7 @@
       </input>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ level=$loglevel2$ cid=* channel=input* | chart count sparkline by channel | sort -count</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ level=$loglevel2$ cid=* channel=input* | chart count sparkline by channel | sort -count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
           <sampleRatio>1</sampleRatio>

--- a/criblvision/default/data/ui/views/stats.xml
+++ b/criblvision/default/data/ui/views/stats.xml
@@ -1,5 +1,21 @@
 <form theme="dark" script="button_click.js" version="1.1">
   <label>Stats</label>
+      <row>
+    <panel>
+      
+      <html rejects="$show_details$">
+        <button id="showButton" class="btn">How to Use</button>
+      </html>
+    </panel>
+  </row>
+  <row>
+    <panel depends="$show_details$">
+      <html>
+        <button id="hideButton" class="btn">Close</button>
+        			<p style="list-style-type:square"><span style="font-size:11pt"><span style="font-family:Arial">This dashboard displays a series of panels with searches based off our minutely log stats. These stats are logged every minute by the api and worker processes. Displayed on this page are CPU and Memory usage, Active vs blocked EP (event processors), event stats, and persistent queue stats. Note: persistent queue on this dashboard can&#8217;t be split by output because, currently, our minutely stats do not include which output these pq events are associated with. For more detailed info on PQ, visit the persistent queue analytics dashboard.&#160;</span></span></p>
+      </html>
+    </panel>
+  </row>
   <description>Based off minutely log stats from the Server channel.</description>
   <fieldset submitButton="true" autoRun="false">
     <input type="time" token="field1" searchWhenChanged="true">
@@ -9,15 +25,30 @@
         <latest>now</latest>
       </default>
     </input>
-    <input type="dropdown" token="host" searchWhenChanged="false">
+    <input type="dropdown" token="worker_group">
+      <label>Worker Group</label>
+      <choice value="*">All Worker Groups</choice>
+      <initialValue>*</initialValue>
+      <fieldForLabel>worker_group</fieldForLabel>
+      <fieldForValue>worker_group</fieldForValue>
+      <search>
+        <query>| inputlookup cribl_stream_workers | stats count BY worker_group</query>
+        <earliest>-24h@h</earliest>
+        <latest>now</latest>
+      </search>
+    </input>
+    <input type="dropdown" token="host">
       <label>Host</label>
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort -host</query>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
+      <choice value="*">All Hosts</choice>
+      <default>*</default>
+      <initialValue>*</initialValue>
     </input>
     <input type="dropdown" token="span">
       <label>span</label>
@@ -38,29 +69,10 @@
   </fieldset>
   <row>
     <panel>
-      <html rejects="$show_details$">
-        <button id="showButton" class="btn">How to Use</button>
-      </html>
-    </panel>
-  </row>
-  <row>
-    <panel depends="$show_details$">
-      <html>
-        <button id="hideButton" class="btn">Close</button>
-        			<p style="list-style-type:square">
-          <span style="font-size:11pt">
-            <span style="font-family:Arial">This dashboard displays a series of panels with searches based off our minutely log stats. These stats are logged every minute by the api and worker processes. Displayed on this page are CPU and Memory usage, Active vs blocked EP (event processors), event stats, and persistent queue stats. Note: persistent queue on this dashboard can’t be split by output because, currently, our minutely stats do not include which output these pq events are associated with. For more detailed info on PQ, visit the persistent queue analytics dashboard. </span>
-          </span>
-        </p>
-      </html>
-    </panel>
-  </row>
-  <row>
-    <panel>
       <chart>
-        <title>CPU Usage</title>
+        <title>Cpu Usage</title>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ channel=server message="_raw stats" | timechart span=$span$ last(cpuPerc) as cpuPerc $splitby$</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart span=$span$ last(cpuPerc) as cpuPerc $splitby$</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -74,14 +86,14 @@
   <row>
     <panel>
       <chart>
-        <title>Memory usage (MB)</title>
+        <title>Memory usage</title>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ channel=server message="_raw stats" | timechart span=$span$ last(mem.ext) as memExt last(mem.heap) as memHeap last(mem.rss) as memRss $splitby$</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart span=$span$ last(mem.ext) as memExt last(mem.heap) as memHeap last(mem.rss) as memRss $splitby$</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
         <option name="charting.chart">area</option>
-        <option name="charting.chart.stackMode">default</option>
+        <option name="charting.chart.stackMode">stacked</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -90,7 +102,7 @@
       <chart>
         <title>Active vs blocked EP</title>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ channel=server message="_raw stats" | timechart span=$span$ last(activeEP) as activeEP last(blockedEP) as blockedEP $splitby$</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart span=$span$ last(activeEP) as activeEP last(blockedEP) as blockedEP $splitby$</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -106,12 +118,12 @@
       <chart>
         <title>Event Stats</title>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ channel=server message="_raw stats" | timechart span=$span$ last(droppedEvents) as DroppedEvents last(outEvents) as outEvents last(inEvents) as inEvents $splitby$</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart span=$span$ last(droppedEvents) as DroppedEvents last(outEvents) as outEvents last(inEvents) as inEvents $splitby$</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
         <option name="charting.chart">area</option>
-        <option name="charting.chart.stackMode">default</option>
+        <option name="charting.chart.stackMode">stacked</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -120,12 +132,12 @@
       <chart>
         <title>Persistent Queue stats</title>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ channel=server message="_raw stats" | timechart span=$span$ last(pqInBytes) as pqInBytes last(pqOutBytes) as pqOutBytes last(pqTotalBytes) as pqTotalBytes $splitby$</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart span=$span$ last(pqInBytes) as pqInBytes last(pqOutBytes) as pqOutBytes last(pqTotalBytes) as pqTotalBytes $splitby$</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
         <option name="charting.chart">area</option>
-        <option name="charting.chart.stackMode">default</option>
+        <option name="charting.chart.stackMode">stacked</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>

--- a/criblvision/default/savedsearches.conf
+++ b/criblvision/default/savedsearches.conf
@@ -1,0 +1,21 @@
+[Populate Cribl Stream Worker Lookup]
+action.email.useNSSubject = 1
+action.webhook.enable_allowlist = 0
+alert.track = 0
+dispatch.earliest_time = -24h@h
+dispatch.latest_time = now
+display.general.type = statistics
+display.page.search.tab = statistics
+display.visualizations.show = 0
+request.ui_dispatch_app = criblvision
+request.ui_dispatch_view = search
+search = |  tstats count WHERE `set_cribl_internal_log_index` BY host \
+|  rename host AS worker\
+|  join type=left left=L right=R WHERE L.worker=R.host \
+    [ | mstats count(*) AS * WHERE `set_cribl_metrics_index` BY host group ]\
+| rename L.worker AS worker R.group AS worker_group\
+| table worker worker_group\
+| where isnotnull(worker_group)
+| inputlookup cribl_stream_workers.csv append=true\
+| dedup worker worker_group\
+| outputlookup cribl_stream_workers.csv

--- a/criblvision/default/transforms.conf
+++ b/criblvision/default/transforms.conf
@@ -1,0 +1,4 @@
+[cribl_stream_workers]
+batch_index_query = 0
+case_sensitive_match = 1
+filename = cribl_stream_workers.csv


### PR DESCRIPTION
Added a dropdown to each of the relevant Splunk dashboards to select a Worker Group to filter results by. This also includes a Saved Search to populate a lookup which maps Worker hostnames to Worker Groups and a definition for that lookup. Note that this change requires an automatic lookup definition to be defined which is not included as it's dependent on the sourcetype used for the internal Cribl Stream logs.