### PR TITLE
fix search to populate worker lookup

### DIFF
--- a/criblvision/default/savedsearches.conf
+++ b/criblvision/default/savedsearches.conf
@@ -13,11 +13,12 @@ request.ui_dispatch_app = criblvision
 request.ui_dispatch_view = search
 search = |  tstats count WHERE `set_cribl_internal_log_index` BY host \
 |  rename host AS worker\
+|  table worker\
 |  join type=left left=L right=R WHERE L.worker=R.host \
-    [ | mstats count(*) AS * WHERE `set_cribl_metrics_index` BY host group ]\
+    [ | mstats avg(_value) WHERE `set_cribl_metrics_index` metric_name=`set_cribl_metrics_prefix("system.cpu_perc")` by host group | table host group ]\
 | rename L.worker AS worker R.group AS worker_group\
 | table worker worker_group\
 | where isnotnull(worker_group)\
 | inputlookup cribl_stream_workers.csv append=true\
 | dedup worker worker_group\
-| outputlookup cribl_stream_workers.csv
+| outputlookup cribl_stream_workers


### PR DESCRIPTION
While testing the new release for version `2.0.0` I noticed that the provided search was throwing the following error in our Splunk Cloud Environment:
![image](https://github.com/criblio/criblvision/assets/24652680/5f8cc029-fe6a-48da-9c5c-fa6f5c435700)

After changing the last line to `| outputlookup cribl_stream_workers` the search ran but was very slow (30 seconds) in our environment with many cribl worker. After debugging I changed the `mstats` part of the search and got result a much faster search (4 seconds) when only looking for the cpu metric which all running workers should have.
