### PR TITLE
Added Deployment Annotations to Time-Series Charts

### DIFF
--- a/criblvision/default/data/ui/views/cribl_stream_license_metrics.xml
+++ b/criblvision/default/data/ui/views/cribl_stream_license_metrics.xml
@@ -1,9 +1,7 @@
 <form version="1.1" theme="dark">
   <label>Cribl Stream License Metrics</label>
   <description></description>
-  <search id="annotation_search">
-    <query>`set_cribl_internal_log_index` source!=cribl action=deploy source="*audit.log*" 
-| eval annotation_category = "deploy", annotation_label = "worker_group=".id.", commit=".version.", user=".user</query>
+  <search id="annotation_search" ref="Deployment Annotations">
     <earliest>$time.earliest$</earliest>
     <latest>$time.latest$</latest>
   </search>

--- a/criblvision/default/data/ui/views/cribl_stream_license_metrics.xml
+++ b/criblvision/default/data/ui/views/cribl_stream_license_metrics.xml
@@ -1,6 +1,12 @@
 <form version="1.1" theme="dark">
   <label>Cribl Stream License Metrics</label>
   <description></description>
+  <search id="annotation_search">
+    <query>`set_cribl_internal_log_index` source!=cribl action=deploy source="*audit.log*" 
+| eval annotation_category = "deploy", annotation_label = "worker_group=".id.", commit=".version.", user=".user</query>
+    <earliest>$time.earliest$</earliest>
+    <latest>$time.latest$</latest>
+  </search>
   <fieldset submitButton="true" autoRun="true">
     <input type="time" searchWhenChanged="false" token="time">
       <label>Time Range</label>
@@ -155,6 +161,7 @@
     <panel>
       <title>Cribl Stream $unit$ In</title>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix(route.in_bytes)`) prestats=true WHERE `set_cribl_metrics_index` span=15m
 | timechart sum(`set_cribl_metrics_prefix(route.in_bytes)`) AS bytes span=15m
@@ -175,6 +182,7 @@
     <panel>
       <title>Cribl Stream $unit$ Out</title>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix(route.out_bytes)`) prestats=true WHERE `set_cribl_metrics_index` span=15m
 | timechart sum(`set_cribl_metrics_prefix(route.out_bytes)`) AS bytes span=15m

--- a/criblvision/default/data/ui/views/cribl_thruput_introspection.xml
+++ b/criblvision/default/data/ui/views/cribl_thruput_introspection.xml
@@ -1,9 +1,7 @@
 <form theme="dark" version="1.1">
   <label>Cribl Thruput Introspection</label>
   <description>Cribl Thruput Introspection</description>
-  <search id="annotation_search">
-    <query>`set_cribl_internal_log_index` source!=cribl action=deploy source="*audit.log*" 
-| eval annotation_category = "deploy", annotation_label = "worker_group=".id.", commit=".version.", user=".user</query>
+  <search id="annotation_search" ref="Deployment Annotations">
     <earliest>$time.earliest$</earliest>
     <latest>$time.latest$</latest>
   </search>

--- a/criblvision/default/data/ui/views/cribl_thruput_introspection.xml
+++ b/criblvision/default/data/ui/views/cribl_thruput_introspection.xml
@@ -1,8 +1,14 @@
 <form theme="dark" version="1.1">
   <label>Cribl Thruput Introspection</label>
   <description>Cribl Thruput Introspection</description>
+  <search id="annotation_search">
+    <query>`set_cribl_internal_log_index` source!=cribl action=deploy source="*audit.log*" 
+| eval annotation_category = "deploy", annotation_label = "worker_group=".id.", commit=".version.", user=".user</query>
+    <earliest>$time.earliest$</earliest>
+    <latest>$time.latest$</latest>
+  </search>
   <fieldset submitButton="true" autoRun="false">
-    <input type="time" searchWhenChanged="true" token="global_time_tok">
+    <input type="time" searchWhenChanged="true" token="time">
       <label>Time Range</label>
       <default>
         <earliest>-15m</earliest>
@@ -76,6 +82,7 @@
       <html>
         <div style="font-family: Arial; font-size: 11pt; list-style-type: square; text-align: center;">
           <p>This dashboard is intended to provide insight into thruput metrics from reported metrics events. Metrics on this dashboard are for your Sources and Destinations. For Destinations, there are two panels which show total events and bytes out by Destination. You can select all or just specific Destinations. The Sources panel will display events and total bytes in. However this dashboard has a few options to help troubleshoot issues specific to uneven distribution of events received by Worker Process which can be an indication of TCP pinning or other issues with the origin sending these events. When selecting the split by of Worker Process, a new panel showing CPU by Worker Process appears underneath the total events in panel. We recommend also setting the stack mode to 100% stacked. This mode will allow you to easily identify if there is one Worker Process that is accepting a significantly higher amount of events and also consuming more CPU than other Workers. A single Worker Process with a high event in count and 100% CPU usage is usually indicative of TCP pinning. </p>
+          <p><b>Note:</b> The <code>CPU Percentage by Worker Process</code> panel search only populates when the Source split by input is set to <code>Worker Process</code></p>
         </div>
       </html>
     </panel>
@@ -95,50 +102,47 @@
         <initialValue>*</initialValue>
         <fieldForLabel>output</fieldForLabel>
         <fieldForValue>output</fieldForValue>
-        <search>
-          <query>| mstats avg(`set_cribl_metrics_prefix("total.out_events")`) WHERE `set_cribl_metrics_index` group=$worker_group$ BY output
-| table output</query>
-          <earliest>$global_time_tok.earliest$</earliest>
-          <latest>$global_time_tok.latest$</latest>
-        </search>
       </input>
+    </panel>
+  </row>
+  <row>
+    <panel>
       <chart>
         <title>Total Events Out</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix("total.out_events")`) AS out_events WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$ $output_token$ $mstats_span$ BY output
 | timechart sum("out_events") $timechart_span$ useother=false BY output WHERE max in top5
 | fields - _span*</query>
-          <earliest>$global_time_tok.earliest$</earliest>
-          <latest>$global_time_tok.latest$</latest>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
         </search>
         <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisY.abbreviation">auto</option>
+        <option name="charting.axisTitleY.text">Event Count</option>
         <option name="charting.chart">line</option>
-        <option name="charting.chart.nullValueMode">connect</option>
-        <option name="charting.chart.showDataLabels">none</option>
         <option name="charting.drilldown">none</option>
-        <option name="charting.gridLinesX.showMajorLines">1</option>
-        <option name="charting.legend.mode">seriesCompare</option>
+        <option name="charting.legend.placement">bottom</option>
         <option name="refresh.display">progressbar</option>
       </chart>
+    </panel>
+  </row>
+  <row>
+    <panel>
       <chart>
         <title>Total Bytes Out</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix("total.out_bytes")`) AS out_bytes  WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$ $output_token$ $mstats_span$ BY output
 | timechart sum("out_bytes") $timechart_span$ useother=false BY output WHERE max in top5
 | fields - _span*</query>
-          <earliest>$global_time_tok.earliest$</earliest>
-          <latest>$global_time_tok.latest$</latest>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
         </search>
         <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisY.abbreviation">auto</option>
+        <option name="charting.axisTitleY.text">Bytes</option>
         <option name="charting.chart">line</option>
-        <option name="charting.chart.nullValueMode">connect</option>
-        <option name="charting.chart.showDataLabels">none</option>
         <option name="charting.drilldown">none</option>
-        <option name="charting.gridLinesX.showMajorLines">1</option>
-        <option name="charting.legend.mode">seriesCompare</option>
-        <option name="refresh.display">progressbar</option>
+        <option name="charting.legend.placement">bottom</option>
       </chart>
     </panel>
   </row>
@@ -193,65 +197,65 @@
         <default>20</default>
         <initialValue>20</initialValue>
       </input>
+    </panel>
+  </row>
+  <row>
+    <panel>
       <chart>
         <title>Total Events In</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix("total.in_events")`) AS in_events  WHERE `set_cribl_metrics_index` group=$worker_group$ $input_token$ $mstats_span$ BY $splitby$
 | timechart sum("in_events") $timechart_span$ useother=false BY $splitby$ WHERE max in top$limit$
 | fields - _span*</query>
-          <earliest>$global_time_tok.earliest$</earliest>
-          <latest>$global_time_tok.latest$</latest>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
         </search>
         <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisY.abbreviation">auto</option>
-        <option name="charting.chart">area</option>
-        <option name="charting.chart.nullValueMode">connect</option>
-        <option name="charting.chart.showDataLabels">none</option>
-        <option name="charting.chart.stackMode">$stackmode$</option>
+        <option name="charting.axisTitleY.text">Event Count</option>
+        <option name="charting.chart">line</option>
         <option name="charting.drilldown">none</option>
-        <option name="charting.gridLinesX.showMajorLines">1</option>
-        <option name="charting.legend.mode">seriesCompare</option>
-        <option name="refresh.display">progressbar</option>
+        <option name="charting.legend.placement">bottom</option>
       </chart>
-      <chart depends="$show_cpu_chart$">
+    </panel>
+  </row>
+  <row>
+    <panel>
+      <chart>
         <title>CPU Percentage by Worker Process</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix("system.cpu_perc")`) AS cpu_perc WHERE `set_cribl_metrics_index` group=$worker_group$ $mstats_span$ BY $splitby$
 | timechart sum("cpu_perc") $timechart_span$ useother=false BY $splitby$ WHERE max in top$limit$
 | fields - _span*</query>
-          <earliest>$global_time_tok.earliest$</earliest>
-          <latest>$global_time_tok.latest$</latest>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
         </search>
         <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisY.abbreviation">auto</option>
-        <option name="charting.chart">area</option>
-        <option name="charting.chart.nullValueMode">connect</option>
-        <option name="charting.chart.showDataLabels">none</option>
-        <option name="charting.chart.stackMode">$stackmode$</option>
+        <option name="charting.axisTitleY.text">CPU %</option>
+        <option name="charting.chart">line</option>
         <option name="charting.drilldown">none</option>
-        <option name="charting.gridLinesX.showMajorLines">1</option>
-        <option name="charting.legend.mode">seriesCompare</option>
-        <option name="refresh.display">progressbar</option>
+        <option name="charting.legend.placement">bottom</option>
       </chart>
+    </panel>
+  </row>
+  <row>
+    <panel>
       <chart>
         <title>Total Bytes In</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix("total.in_bytes")`) AS in_bytes  WHERE `set_cribl_metrics_index` group=$worker_group$ $input_token$ $mstats_span$ BY $splitby$
 | timechart sum("in_bytes") $timechart_span$ useother=false BY $splitby$ WHERE max in top$limit$
 | fields - _span*</query>
-          <earliest>$global_time_tok.earliest$</earliest>
-          <latest>$global_time_tok.latest$</latest>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
         </search>
         <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisY.abbreviation">auto</option>
-        <option name="charting.chart">area</option>
-        <option name="charting.chart.nullValueMode">connect</option>
-        <option name="charting.chart.showDataLabels">none</option>
-        <option name="charting.chart.stackMode">$stackmode$</option>
+        <option name="charting.axisTitleY.text">Bytes</option>
+        <option name="charting.chart">line</option>
         <option name="charting.drilldown">none</option>
-        <option name="charting.gridLinesX.showMajorLines">1</option>
-        <option name="charting.legend.mode">seriesCompare</option>
-        <option name="refresh.display">progressbar</option>
+        <option name="charting.legend.placement">bottom</option>
       </chart>
     </panel>
   </row>

--- a/criblvision/default/data/ui/views/health_check.xml
+++ b/criblvision/default/data/ui/views/health_check.xml
@@ -1,5 +1,11 @@
 <form theme="dark" version="1.1">
   <label>Health Check</label>
+  <search id="annotation_search">
+    <query>`set_cribl_internal_log_index` source!=cribl action=deploy source="*audit.log*" 
+| eval annotation_category = "deploy", annotation_label = "worker_group=".id.", commit=".version.", user=".user</query>
+    <earliest>$time.earliest$</earliest>
+    <latest>$time.latest$</latest>
+  </search>
   <fieldset submitButton="true" autoRun="false">
     <input type="time" token="time" searchWhenChanged="true">
       <label>Time Range</label>

--- a/criblvision/default/data/ui/views/health_check.xml
+++ b/criblvision/default/data/ui/views/health_check.xml
@@ -1,8 +1,6 @@
 <form theme="dark" version="1.1">
   <label>Health Check</label>
-  <search id="annotation_search">
-    <query>`set_cribl_internal_log_index` source!=cribl action=deploy source="*audit.log*" 
-| eval annotation_category = "deploy", annotation_label = "worker_group=".id.", commit=".version.", user=".user</query>
+  <search id="annotation_search" ref="Deployment Annotations">
     <earliest>$time.earliest$</earliest>
     <latest>$time.latest$</latest>
   </search>

--- a/criblvision/default/data/ui/views/leader_performance_introspection.xml
+++ b/criblvision/default/data/ui/views/leader_performance_introspection.xml
@@ -1,5 +1,11 @@
 <form theme="dark" version="1.1">
   <label>Leader Performance Introspection</label>
+  <search id="annotation_search">
+    <query>`set_cribl_internal_log_index` source!=cribl action=deploy source="*audit.log*" 
+| eval annotation_category = "deploy", annotation_label = "worker_group=".id.", commit=".version.", user=".user</query>
+    <earliest>$time.earliest$</earliest>
+    <latest>$time.latest$</latest>
+  </search>
   <fieldset submitButton="true" autoRun="false">
     <input type="time" token="time" searchWhenChanged="true">
       <label>Time Range</label>
@@ -114,6 +120,7 @@
     <panel>
       <title>Leader CPU by API Process</title>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>`set_cribl_internal_log_index` host=$host$ channel=ProcessMetrics cid IN ("api", "service:*")
 | timechart limit=1000 useother=f max(cpuPerc) AS max_cpuPerc by cid</query>
@@ -172,6 +179,7 @@
         <default></default>
       </input>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>`set_cribl_internal_log_index` host=$host$ source IN ("*/access.log", "*/access1.log", "*/access2.log", "*/access3.log", "*/access4.log") response_time=*
 | timechart limit=1000 useother=f sum(response_time) AS sum_response_time $splitby$</query>

--- a/criblvision/default/data/ui/views/leader_performance_introspection.xml
+++ b/criblvision/default/data/ui/views/leader_performance_introspection.xml
@@ -1,8 +1,6 @@
 <form theme="dark" version="1.1">
   <label>Leader Performance Introspection</label>
-  <search id="annotation_search">
-    <query>`set_cribl_internal_log_index` source!=cribl action=deploy source="*audit.log*" 
-| eval annotation_category = "deploy", annotation_label = "worker_group=".id.", commit=".version.", user=".user</query>
+  <search id="annotation_search" ref="Deployment Annotations">
     <earliest>$time.earliest$</earliest>
     <latest>$time.latest$</latest>
   </search>

--- a/criblvision/default/data/ui/views/persistent_queue_analytics.xml
+++ b/criblvision/default/data/ui/views/persistent_queue_analytics.xml
@@ -1,8 +1,6 @@
 <form theme="dark" version="1.1">
   <label>Persistent Queue Analytics</label>
-  <search id="annotation_search">
-    <query>`set_cribl_internal_log_index` source!=cribl action=deploy source="*audit.log*" 
-| eval annotation_category = "deploy", annotation_label = "worker_group=".id.", commit=".version.", user=".user</query>
+  <search id="annotation_search" ref="Deployment Annotations">
     <earliest>$time.earliest$</earliest>
     <latest>$time.latest$</latest>
   </search>

--- a/criblvision/default/data/ui/views/persistent_queue_analytics.xml
+++ b/criblvision/default/data/ui/views/persistent_queue_analytics.xml
@@ -1,5 +1,11 @@
 <form theme="dark" version="1.1">
   <label>Persistent Queue Analytics</label>
+  <search id="annotation_search">
+    <query>`set_cribl_internal_log_index` source!=cribl action=deploy source="*audit.log*" 
+| eval annotation_category = "deploy", annotation_label = "worker_group=".id.", commit=".version.", user=".user</query>
+    <earliest>$time.earliest$</earliest>
+    <latest>$time.latest$</latest>
+  </search>
   <fieldset submitButton="true" autoRun="false">
     <input type="time" token="time" searchWhenChanged="true">
       <label>Time Range</label>
@@ -146,6 +152,7 @@
     <panel>
       <title>PQ Size by Destination</title>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) WHERE `set_cribl_metrics_index` "host"=$host$ group=$worker_group$ span=auto BY output prestats=true
 | timechart sum(`set_cribl_metrics_prefix("pq.queue_size")`) useother=false BY output WHERE max in top100

--- a/criblvision/default/data/ui/views/stats.xml
+++ b/criblvision/default/data/ui/views/stats.xml
@@ -1,6 +1,12 @@
 <form theme="dark" version="1.1">
   <label>Stats</label>
   <description>Based off minutely log stats from the Server channel.</description>
+  <search id="annotation_search">
+    <query>`set_cribl_internal_log_index` source!=cribl action=deploy source="*audit.log*" 
+| eval annotation_category = "deploy", annotation_label = "worker_group=".id.", commit=".version.", user=".user</query>
+    <earliest>$time.earliest$</earliest>
+    <latest>$time.latest$</latest>
+  </search>
   <fieldset submitButton="true" autoRun="false">
     <input type="time" token="time" searchWhenChanged="true">
       <label>Time Range</label>
@@ -36,14 +42,21 @@
     </input>
     <input type="dropdown" token="span">
       <label>Time Span</label>
+      <choice value="auto">Auto</choice>
       <choice value="1m">1m</choice>
       <choice value="5m">5m</choice>
       <choice value="15m">15m</choice>
       <choice value="30m">30m</choice>
       <choice value="1h">1h</choice>
       <choice value="1d">1d</choice>
-      <default>1m</default>
-      <initialValue>1m</initialValue>
+      <default>auto</default>
+      <initialValue>auto</initialValue>
+      <change>
+        <condition value="auto">
+          <set token="span"></set>
+        </condition>
+      </change>
+      <prefix>span=</prefix>
     </input>
     <input type="dropdown" token="splitby" searchWhenChanged="true">
       <label>Split by Worker Process</label>
@@ -82,8 +95,9 @@
     <panel>
       <chart>
         <title>CPU Usage</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart span=$span$ last(cpuPerc) as cpuPerc $splitby$</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart $span$ last(cpuPerc) as cpuPerc $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
@@ -101,8 +115,9 @@
     <panel>
       <chart>
         <title>Memory Usage</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart span=$span$ last(mem.ext) as memExt last(mem.heap) as memHeap last(mem.rss) as memRss $splitby$</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart $span$ last(mem.ext) as memExt last(mem.heap) as memHeap last(mem.rss) as memRss $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
@@ -119,8 +134,9 @@
     <panel>
       <chart>
         <title>Active vs Blocked Event Processors</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart span=$span$ last(activeEP) as activeEP last(blockedEP) as blockedEP $splitby$</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart $span$ last(activeEP) as activeEP last(blockedEP) as blockedEP $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
@@ -139,14 +155,16 @@
     <panel>
       <chart>
         <title>Event Stats</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart span=$span$ last(droppedEvents) as DroppedEvents last(outEvents) as outEvents last(inEvents) as inEvents $splitby$</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart $span$ last(droppedEvents) as DroppedEvents last(outEvents) as outEvents last(inEvents) as inEvents $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Count</option>
         <option name="charting.chart">area</option>
+        <option name="charting.chart.nullValueMode">zero</option>
         <option name="charting.chart.stackMode">stacked</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.legend.placement">bottom</option>
@@ -156,14 +174,16 @@
     <panel>
       <chart>
         <title>Persistent Queue Stats</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
-          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart span=$span$ last(pqInBytes) as pqInBytes last(pqOutBytes) as pqOutBytes last(pqTotalBytes) as pqTotalBytes $splitby$</query>
+          <query>`set_cribl_internal_log_index` host=$host$ worker_group=$worker_group$ channel=server message="_raw stats" | timechart $span$ last(pqInBytes) as pqInBytes last(pqOutBytes) as pqOutBytes last(pqTotalBytes) as pqTotalBytes $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Size (B)</option>
         <option name="charting.chart">area</option>
+        <option name="charting.chart.nullValueMode">zero</option>
         <option name="charting.chart.stackMode">stacked</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.legend.placement">bottom</option>

--- a/criblvision/default/data/ui/views/stats.xml
+++ b/criblvision/default/data/ui/views/stats.xml
@@ -1,9 +1,7 @@
 <form theme="dark" version="1.1">
   <label>Stats</label>
   <description>Based off minutely log stats from the Server channel.</description>
-  <search id="annotation_search">
-    <query>`set_cribl_internal_log_index` source!=cribl action=deploy source="*audit.log*" 
-| eval annotation_category = "deploy", annotation_label = "worker_group=".id.", commit=".version.", user=".user</query>
+  <search id="annotation_search" ref="Deployment Annotations">
     <earliest>$time.earliest$</earliest>
     <latest>$time.latest$</latest>
   </search>

--- a/criblvision/default/savedsearches.conf
+++ b/criblvision/default/savedsearches.conf
@@ -21,3 +21,17 @@ search = |  tstats count WHERE `set_cribl_internal_log_index` BY host \
 | inputlookup cribl_stream_workers.csv append=true\
 | dedup worker worker_group\
 | outputlookup cribl_stream_workers.csv
+
+[Deployment Annotations]
+action.email.useNSSubject = 1
+action.webhook.enable_allowlist = 0
+alert.track = 0
+description = Used for annotating time-series charts on dashboards with information regarding deployments that have happened in the selected time range
+dispatch.earliest_time = -24h@h
+dispatch.latest_time = now
+display.general.timeRangePicker.show = 0
+display.visualizations.show = 0
+request.ui_dispatch_app = criblvision
+request.ui_dispatch_view = search
+search = `set_cribl_internal_log_index` source!=cribl action=deploy source="*audit.log*" \
+| eval annotation_category = "deploy", annotation_label = "worker_group=".id.", commit=".version.", user=".user


### PR DESCRIPTION
Dashboard panels that use time-series charts have been updated to include annotations that inform the user of deployments that have occurred during the selected time range.