### PR TITLE
Add sourcetype to dashboard host pulldown populating searches

### DIFF
--- a/criblvision/default/data/ui/views/audit.xml
+++ b/criblvision/default/data/ui/views/audit.xml
@@ -13,7 +13,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort -host</query>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` `set_cribl_log_sourcetype` | mvexpand host | sort -host</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>

--- a/criblvision/default/data/ui/views/auditlogs.xml
+++ b/criblvision/default/data/ui/views/auditlogs.xml
@@ -13,7 +13,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index` source IN ("*/audit.log", "*/audit1.log", "*/audit2.log", "*/audit3.log", "*/audit4.log") NOT [| inputlookup cribl_stream_workers | rename worker AS host | table host ]
+        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index` `set_cribl_log_sourcetype` source IN ("*/audit.log", "*/audit1.log", "*/audit2.log", "*/audit3.log", "*/audit4.log") NOT [| inputlookup cribl_stream_workers | rename worker AS host | table host ]
 | mvexpand host
 | sort host</query>
         <earliest>$time.earliest$</earliest>

--- a/criblvision/default/data/ui/views/commit_and_deploy_audit_logs.xml
+++ b/criblvision/default/data/ui/views/commit_and_deploy_audit_logs.xml
@@ -13,7 +13,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index` source IN ("*/audit.log", "*/audit1.log", "*/audit2.log", "*/audit3.log", "*/audit4.log") NOT [| inputlookup cribl_stream_workers | rename worker AS host | table host ]
+        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index` `set_cribl_log_sourcetype` source IN ("*/audit.log", "*/audit1.log", "*/audit2.log", "*/audit3.log", "*/audit4.log") NOT [| inputlookup cribl_stream_workers | rename worker AS host | table host ]
 | mvexpand host
 | sort host</query>
         <earliest>$time.earliest$</earliest>

--- a/criblvision/default/data/ui/views/cribl_thruput_introspection.xml
+++ b/criblvision/default/data/ui/views/cribl_thruput_introspection.xml
@@ -30,7 +30,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` `set_cribl_log_sourcetype` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>

--- a/criblvision/default/data/ui/views/health_check.xml
+++ b/criblvision/default/data/ui/views/health_check.xml
@@ -29,7 +29,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` 
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` `set_cribl_log_sourcetype`
 | mvexpand host 
 | sort host
 | lookup cribl_stream_workers worker AS host

--- a/criblvision/default/data/ui/views/home.xml
+++ b/criblvision/default/data/ui/views/home.xml
@@ -25,7 +25,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` `set_cribl_log_sourcetype` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>

--- a/criblvision/default/data/ui/views/job_inspector.xml
+++ b/criblvision/default/data/ui/views/job_inspector.xml
@@ -12,7 +12,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index` AND source IN ("*state/jobs/*") | mvexpand host | sort host</query>
+        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index` `set_cribl_log_sourcetype` AND source IN ("*state/jobs/*") | mvexpand host | sort host</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>

--- a/criblvision/default/data/ui/views/leader_performance_introspection.xml
+++ b/criblvision/default/data/ui/views/leader_performance_introspection.xml
@@ -17,7 +17,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` NOT [| inputlookup cribl_stream_workers | rename worker AS host | table host ] | mvexpand host | sort host</query>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` `set_cribl_log_sourcetype` NOT [| inputlookup cribl_stream_workers | rename worker AS host | table host ] | mvexpand host | sort host</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>

--- a/criblvision/default/data/ui/views/persistent_queue_analytics.xml
+++ b/criblvision/default/data/ui/views/persistent_queue_analytics.xml
@@ -29,7 +29,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` `set_cribl_log_sourcetype` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>

--- a/criblvision/default/data/ui/views/sizingcalculator.xml
+++ b/criblvision/default/data/ui/views/sizingcalculator.xml
@@ -25,7 +25,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index()`| mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
+        <query>| tstats values(host) AS host WHERE `set_cribl_internal_log_index()` `set_cribl_log_sourcetype` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
         <earliest>0</earliest>
         <latest></latest>
       </search>

--- a/criblvision/default/data/ui/views/sources_and_destinations_overview.xml
+++ b/criblvision/default/data/ui/views/sources_and_destinations_overview.xml
@@ -40,7 +40,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` `set_cribl_log_sourcetype` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>

--- a/criblvision/default/data/ui/views/stats.xml
+++ b/criblvision/default/data/ui/views/stats.xml
@@ -30,7 +30,7 @@
       <fieldForLabel>host</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| tstats values(host) as host where `set_cribl_internal_log_index` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
+        <query>| tstats values(host) as host where `set_cribl_internal_log_index` `set_cribl_log_sourcetype` | mvexpand host | sort host | lookup cribl_stream_workers worker AS host | search worker_group=$worker_group$</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>


### PR DESCRIPTION
Dashboard 'Host' pulldown populating searches should use configured sourcetype (via \`set_cribl_log_sourcetype\`) to avoid pulling in extraneous hosts from shared indexes.
