### PR TITLE
Environment Filtering on Dashboards

### DIFF
--- a/criblvision/README
+++ b/criblvision/README
@@ -66,13 +66,19 @@ This app ships with four macros which must be edited in accordance with your spl
   <tr>
    <td>set_cribl_metrics_index
    </td>
-   <td>Macro definition for the index you configured for cribl metrics
+   <td>Set this macro definition to the index you configured for cribl metrics.
    </td>
   </tr>
   <tr>
    <td>set_cribl_metrics_prefix(1)
    </td>
    <td>Change the "cribl.logstream" value before .$metric_name$ if you have changed the default namespace used for metrics on your cribl metrics internal source. 
+   </td>
+  </tr>
+  <tr>
+   <td>set_cribl_environment_field_name
+   </td>
+   <td>(Optional) Set this macro definition to the name of the field that specifies the environment a Cribl Stream instance belongs to.
    </td>
   </tr>
 </table>
@@ -91,6 +97,9 @@ definition = index=cribl_metrics
 
 [set_cribl_metrics_prefix(1)]
 definition = cribl.logstream.$metric_name$
+
+[set_cribl_environment_field_name]
+definition = env
 ```
 
 #### **Leader logs**

--- a/criblvision/appserver/static/javascript/views/app.js
+++ b/criblvision/appserver/static/javascript/views/app.js
@@ -11,7 +11,8 @@ define(['react', 'splunkjs/splunk'], function(react, splunk_js_sdk){
         set_cribl_internal_log_index: 'cribl_logs',
         set_cribl_log_sourcetype: '',
         set_cribl_metrics_index: 'cribl_metrics',
-        set_cribl_metrics_prefix: 'cribl.logstream.'
+        set_cribl_metrics_prefix: 'cribl.logstream.',
+        set_cribl_environment_field_name: 'env'
       };
 
       this.handleChange = this.handleChange.bind(this);
@@ -59,6 +60,10 @@ define(['react', 'splunkjs/splunk'], function(react, splunk_js_sdk){
             e('p', { style: { display: 'table-row' } }, [
               e('label', { style: { display: 'table-cell', textAlign: 'left', marginBottom: '1em', paddingRight: '1em' } }, 'Cribl Metrics Prefix:'),
               e('input', { style: { display: 'table-cell', marginBottom: '1em' }, type: 'text', name: 'set_cribl_metrics_prefix', value: this.state.set_cribl_metrics_prefix, onChange: this.handleChange })
+            ]),
+            e('p', { style: { display: 'table-row' } }, [
+              e('label', { style: { display: 'table-cell', textAlign: 'left', marginBottom: '1em', paddingRight: '1em' } }, 'Cribl Environment Field Name:'),
+              e('input', { style: { display: 'table-cell', marginBottom: '1em' }, type: 'text', name: 'set_cribl_environment_field_name', value: this.state.set_cribl_environment_field_name, onChange: this.handleChange })
             ])
           ]))
         ]),
@@ -73,7 +78,7 @@ define(['react', 'splunkjs/splunk'], function(react, splunk_js_sdk){
             e('a', { href: 'https://docs.cribl.io/edge/deploy-planning', target: '_blank' }, 'here'),
             '. ',
             e('b', null, 'NOTE:'),
-            ' When deploying the Edge node to your Leader node, we recommend having a separate fleet just for this node. Be sure to disable all other inputs on that Edge node except for file monitor inputs.'
+            ' When deploying the Edge Node to your Leader Node, we recommend having a separate Fleet just for this Node. Be sure to disable all other inputs on that Edge Node except for file monitor inputs.'
           ])
         ]),
         e('div', null, [

--- a/criblvision/default/data/ui/views/README
+++ b/criblvision/default/data/ui/views/README
@@ -14,6 +14,8 @@ Version 3.x of the CriblVision app introduces a new Cribl Stream asset lookup to
     * Clicking the link in the navigation bar
 4. Double check that any alerts that were enabled are still enabled
 
+If there are issues after completing these steps, you may need to clear your browser cache to clear cached scripts in Splunk. Clear the browser cache and follow from instructions from step 2 onwards.
+
 If installing the app through other methods, refer to the documentation below on how to configure the app and update your configuration accordingly.
 
 ## Getting started
@@ -64,13 +66,19 @@ This app ships with four macros which must be edited in accordance with your spl
   <tr>
    <td>set_cribl_metrics_index
    </td>
-   <td>Macro definition for the index you configured for cribl metrics
+   <td>Set this macro definition to the index you configured for cribl metrics.
    </td>
   </tr>
   <tr>
    <td>set_cribl_metrics_prefix(1)
    </td>
    <td>Change the "cribl.logstream" value before .$metric_name$ if you have changed the default namespace used for metrics on your cribl metrics internal source. 
+   </td>
+  </tr>
+  <tr>
+   <td>set_cribl_environment_field_name
+   </td>
+   <td>(Optional) Set this macro definition to the name of the field that specifies the environment a Cribl Stream instance belongs to.
    </td>
   </tr>
 </table>
@@ -89,6 +97,9 @@ definition = index=cribl_metrics
 
 [set_cribl_metrics_prefix(1)]
 definition = cribl.logstream.$metric_name$
+
+[set_cribl_environment_field_name]
+definition = env
 ```
 
 #### **Leader logs**

--- a/criblvision/default/data/ui/views/audit.xml
+++ b/criblvision/default/data/ui/views/audit.xml
@@ -8,12 +8,33 @@
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="environment" searchWhenChanged="true">
+      <label>Environment</label>
+      <choice value="*">All Environments</choice>
+      <fieldForLabel>environment</fieldForLabel>
+      <fieldForValue>hosts</fieldForValue>
+      <search>
+        <query>| `dashboard_cribl_environment_filter`</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition label="All Environments">
+          <set token="environment_filter"></set>
+        </condition>
+        <condition>
+          <set token="environment_filter">host IN ($environment$)</set>
+        </condition>
+      </change>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
     <input type="dropdown" token="host" searchWhenChanged="true">
       <label>Host</label>
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| `dashboard_host_filter`</query>
+        <query>| `dashboard_host_filter($environment_filter|s$)`</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
@@ -29,7 +50,7 @@
       <title>Successful Logins by User</title>
       <chart>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ channel=auth message="Successful login" 
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ channel=auth message="Successful login" 
 | timechart count limit=100 by user</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -47,7 +68,7 @@
       <title>Latest Configuration Updates by Worker</title>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ message="finished config update" 
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ message="finished config update" 
 | table _time worker version
 | rename worker AS Worker version AS Version</query>
           <earliest>$time.earliest$</earliest>

--- a/criblvision/default/data/ui/views/auditlogs.xml
+++ b/criblvision/default/data/ui/views/auditlogs.xml
@@ -8,12 +8,33 @@
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="environment" searchWhenChanged="true">
+      <label>Environment</label>
+      <choice value="*">All Environments</choice>
+      <fieldForLabel>environment</fieldForLabel>
+      <fieldForValue>hosts</fieldForValue>
+      <search>
+        <query>| `dashboard_cribl_environment_filter`</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition label="All Environments">
+          <set token="environment_filter"></set>
+        </condition>
+        <condition>
+          <set token="environment_filter">host IN ($environment$)</set>
+        </condition>
+      </change>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
     <input type="dropdown" token="host">
       <label>Leader Host</label>
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| `dashboard_host_filter("instance_type=leader")`</query>
+        <query>| `dashboard_host_filter("instance_type=leader $environment_filter|s$")`</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>
@@ -54,7 +75,7 @@
     <panel>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ source IN ("*/audit.log", "*/audit1.log", "*/audit2.log", "*/audit3.log", "*/audit4.log") type!="expression" action!="commit" action!="deploy"
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ source IN ("*/audit.log", "*/audit1.log", "*/audit2.log", "*/audit3.log", "*/audit4.log") type!="expression" action!="commit" action!="deploy"
 | stats values("caseNumber") AS caseNumber values("email") AS email values("filename") AS filename values("group") AS group values("guids") AS guids values("id") AS id values("path") AS path values("rows") AS rows values("size") AS size values("type") AS type by _time action user delim=", "
 | eval id=if(type="system-info", path, id)
 | eval id=if((action="send" AND type="system-info"), caseNumber, id)

--- a/criblvision/default/data/ui/views/commit_and_deploy_audit_logs.xml
+++ b/criblvision/default/data/ui/views/commit_and_deploy_audit_logs.xml
@@ -8,12 +8,33 @@
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="environment" searchWhenChanged="true">
+      <label>Environment</label>
+      <choice value="*">All Environments</choice>
+      <fieldForLabel>environment</fieldForLabel>
+      <fieldForValue>hosts</fieldForValue>
+      <search>
+        <query>| `dashboard_cribl_environment_filter`</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition label="All Environments">
+          <set token="environment_filter"></set>
+        </condition>
+        <condition>
+          <set token="environment_filter">host IN ($environment$)</set>
+        </condition>
+      </change>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
     <input type="dropdown" token="host">
       <label>Leader Host</label>
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| `dashboard_host_filter("instance_type=leader")`</query>
+        <query>| `dashboard_host_filter("instance_type=leader $environment_filter|s$")`</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>
@@ -70,7 +91,7 @@
     <panel>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ source IN ("*/audit.log", "*/audit1.log", "*/audit2.log", "*/audit3.log", "*/audit4.log") (action=commit AND type=git AND id!="") OR (action=deploy AND type=groups AND id!="") 
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ source IN ("*/audit.log", "*/audit1.log", "*/audit2.log", "*/audit3.log", "*/audit4.log") (action=commit AND type=git AND id!="") OR (action=deploy AND type=groups AND id!="") 
 | eval WorkerGroup=case(action="deploy", id), CommitVersion=case(action="deploy", version, action="commit", id), DeployTime=case(action="deploy", time), CommitTime=case(action="commit", time), isDeployed=if(action="deploy", "1", "0")
 | stats values(user) AS User values(WorkerGroup) AS WorkerGroup values(CommitTime) AS CommitTime values(files.created{}) AS FilesCreated values(files.modified{}) AS FilesModified values(files.deleted{}) AS FilesDeleted max(isDeployed) AS isDeployed values(DeployTime) AS DeployTime latest(_time) AS _time by CommitVersion
 | sort 0 - _time

--- a/criblvision/default/data/ui/views/cribl_stream_assets.xml
+++ b/criblvision/default/data/ui/views/cribl_stream_assets.xml
@@ -6,13 +6,14 @@
   </search>
   <search id="overview_base_search">
     <query>| inputlookup cribl_stream_assets
+| search $environment_filter$
 | stats count(eval(status == "active")) AS active count AS total BY instance_type
 | eval value = tostring(active, "commas")." / ".tostring(total, "commas")</query>
     <earliest>$time.earliest$</earliest>
     <latest>$time.latest$</latest>
   </search>
   <search id="active_assets_base_search">
-    <query>| tstats count WHERE `set_cribl_internal_log_index` `set_cribl_log_sourcetype` BY host _time span=auto
+    <query>| tstats count WHERE `set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ BY host _time span=auto
 | lookup cribl_stream_assets host
 | eval status = if(count &gt; 0, "active", "missing")
 | timechart count(eval(status == "active")) AS active BY instance_type</query>
@@ -31,6 +32,27 @@
         <earliest>-15m</earliest>
         <latest>now</latest>
       </default>
+    </input>
+    <input type="dropdown" token="environment" searchWhenChanged="true">
+      <label>Environment</label>
+      <choice value="*">All Environments</choice>
+      <fieldForLabel>environment</fieldForLabel>
+      <fieldForValue>hosts</fieldForValue>
+      <search>
+        <query>| `dashboard_cribl_environment_filter`</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition label="All Environments">
+          <set token="environment_filter"></set>
+        </condition>
+        <condition>
+          <set token="environment_filter">host IN ($environment$)</set>
+        </condition>
+      </change>
+      <default>*</default>
+      <initialValue>*</initialValue>
     </input>
     <input type="link" token="how_to_use">
       <label>How to Use</label>
@@ -119,11 +141,11 @@
     <panel depends="$show_leader_overview$">
       <chart>
         <title>Leader Node Log Activity</title>
+        <search base="annotation_search" type="annotation"></search>
         <search base="active_assets_base_search">
           <query>
 | table _time leader</query>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Active Leader Node(s)</option>
         <option name="charting.chart">area</option>
@@ -134,11 +156,11 @@
     <panel depends="$show_worker_overview$">
       <chart>
         <title>Worker Node Log Activity</title>
+        <search base="annotation_search" type="annotation"></search>
         <search base="active_assets_base_search">
           <query>
 | table _time worker</query>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Active Worker Node(s)</option>
         <option name="charting.chart">area</option>
@@ -149,11 +171,11 @@
     <panel depends="$show_single_overview$">
       <chart>
         <title>Single Node Log Activity</title>
+        <search base="annotation_search" type="annotation"></search>
         <search base="active_assets_base_search">
           <query>
 | table _time single</query>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleX.visibility">visible</option>
         <option name="charting.axisTitleY.text">Active Single Node(s)</option>
@@ -179,11 +201,11 @@
         <title>Cribl Stream Asset Overview</title>
         <search>
           <query>| inputlookup cribl_stream_assets
-| search $status$
-| table host instance_type worker_group latest_activity_time latest_shutdown_time status
+| search $status$ $environment_filter$
+| table host `set_cribl_environment_field_name` instance_type worker_group latest_activity_time latest_shutdown_time status
 | foreach latest_*_time 
     [ eval &lt;&lt;FIELD&gt;&gt; = strftime(&lt;&lt;FIELD&gt;&gt;, "%Y-%m-%dT%H:%M:%S.%3N") ] 
-| rename host AS Host instance_type AS "Instance Type" worker_group AS "Worker Group" latest_activity_time AS "Latest Activity Time" latest_shutdown_time AS "Latest Shutdown Time" status AS Status</query>
+| rename host AS Host `set_cribl_environment_field_name` AS Environment instance_type AS "Instance Type" worker_group AS "Worker Group" latest_activity_time AS "Latest Activity Time" latest_shutdown_time AS "Latest Shutdown Time" status AS Status</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
@@ -203,6 +225,7 @@
         <title>Cribl Stream Asset Status</title>
         <search>
           <query>| inputlookup cribl_stream_assets
+| search $environment_filter$
 | stats count BY status</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>

--- a/criblvision/default/data/ui/views/cribl_stream_license_metrics.xml
+++ b/criblvision/default/data/ui/views/cribl_stream_license_metrics.xml
@@ -13,6 +13,27 @@
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="environment" searchWhenChanged="true">
+      <label>Environment</label>
+      <choice value="*">All Environments</choice>
+      <fieldForLabel>environment</fieldForLabel>
+      <fieldForValue>hosts</fieldForValue>
+      <search>
+        <query>| `dashboard_cribl_environment_filter`</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition label="All Environments">
+          <set token="environment_filter"></set>
+        </condition>
+        <condition>
+          <set token="environment_filter">host IN ($environment$)</set>
+        </condition>
+      </change>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
     <input type="dropdown" token="unit" searchWhenChanged="true">
       <label>Unit</label>
       <choice value="bytes">Bytes</choice>
@@ -53,7 +74,7 @@
       <title>Cribl Stream $unit$ In</title>
       <single>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(route.in_bytes)`) prestats=true WHERE `set_cribl_metrics_index` span=1h
+          <query>| mstats sum(`set_cribl_metrics_prefix(route.in_bytes)`) prestats=true WHERE `set_cribl_metrics_index` $environment_filter$ span=1h
 | stats sum(`set_cribl_metrics_prefix(route.in_bytes)`) AS bytes
 | eval KB=round(bytes/1024, 4)
 | eval MB=round(bytes/1024/1024, 4)
@@ -78,7 +99,7 @@
       <title>Cribl Stream $unit$ Out</title>
       <single>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(route.out_bytes)`) prestats=true WHERE `set_cribl_metrics_index` span=1h
+          <query>| mstats sum(`set_cribl_metrics_prefix(route.out_bytes)`) prestats=true WHERE `set_cribl_metrics_index` $environment_filter$ span=1h
 | stats sum(`set_cribl_metrics_prefix(route.out_bytes)`) AS bytes
 | eval KB=round(bytes/1024, 4)
 | eval MB=round(bytes/1024/1024, 4)
@@ -102,7 +123,7 @@
       <title>Cribl Stream $unit$ Volume Reduction</title>
       <single>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(route.*_bytes)`) AS bytes_* WHERE `set_cribl_metrics_index`
+          <query>| mstats sum(`set_cribl_metrics_prefix(route.*_bytes)`) AS bytes_* WHERE `set_cribl_metrics_index` $environment_filter$
 | eval KB_in=round(bytes_in/1024, 4), KB_out=round(bytes_out/1024, 4)
 | eval MB_in=round(bytes_in/1024/1024, 4), MB_out=round(bytes_out/1024/1024, 4)
 | eval GB_in=round(bytes_in/1024/1024/1024, 4), GB_out=round(bytes_out/1024/1024/1024, 4)
@@ -131,7 +152,7 @@
       <title>Cribl Stream $unit$ Volume Reduction %</title>
       <single>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(route.*_bytes)`) AS bytes_* WHERE `set_cribl_metrics_index`
+          <query>| mstats sum(`set_cribl_metrics_prefix(route.*_bytes)`) AS bytes_* WHERE `set_cribl_metrics_index` $environment_filter$
 | eval KB_in=round(bytes_in/1024, 4), KB_out=round(bytes_out/1024, 4)
 | eval MB_in=round(bytes_in/1024/1024, 4), MB_out=round(bytes_out/1024/1024, 4)
 | eval GB_in=round(bytes_in/1024/1024/1024, 4), GB_out=round(bytes_out/1024/1024/1024, 4)
@@ -159,9 +180,8 @@
     <panel>
       <title>Cribl Stream $unit$ In</title>
       <chart>
-        <search base="annotation_search" type="annotation"></search>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(route.in_bytes)`) prestats=true WHERE `set_cribl_metrics_index` span=15m
+          <query>| mstats sum(`set_cribl_metrics_prefix(route.in_bytes)`) prestats=true WHERE `set_cribl_metrics_index` $environment_filter$ span=15m
 | timechart sum(`set_cribl_metrics_prefix(route.in_bytes)`) AS bytes span=15m
 | table _time bytes
 | eval KB=round(bytes/1024, 4)
@@ -171,18 +191,19 @@
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.chart">area</option>
         <option name="charting.drilldown">all</option>
         <option name="charting.legend.placement">bottom</option>
+        <option name="refresh.display">progressbar</option>
       </chart>
     </panel>
     <panel>
       <title>Cribl Stream $unit$ Out</title>
       <chart>
-        <search base="annotation_search" type="annotation"></search>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(route.out_bytes)`) prestats=true WHERE `set_cribl_metrics_index` span=15m
+          <query>| mstats sum(`set_cribl_metrics_prefix(route.out_bytes)`) prestats=true WHERE `set_cribl_metrics_index` $environment_filter$ span=15m
 | timechart sum(`set_cribl_metrics_prefix(route.out_bytes)`) AS bytes span=15m
 | table _time bytes
 | eval KB=round(bytes/1024, 4)
@@ -193,6 +214,7 @@
           <latest>$time.latest$</latest>
           <sampleRatio>1</sampleRatio>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.chart">area</option>
         <option name="charting.chart.showDataLabels">minmax</option>

--- a/criblvision/default/data/ui/views/cribl_thruput_introspection.xml
+++ b/criblvision/default/data/ui/views/cribl_thruput_introspection.xml
@@ -13,6 +13,27 @@
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="environment" searchWhenChanged="true">
+      <label>Environment</label>
+      <choice value="*">All Environments</choice>
+      <fieldForLabel>environment</fieldForLabel>
+      <fieldForValue>hosts</fieldForValue>
+      <search>
+        <query>| `dashboard_cribl_environment_filter`</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition label="All Environments">
+          <set token="environment_filter"></set>
+        </condition>
+        <condition>
+          <set token="environment_filter">host IN ($environment$)</set>
+        </condition>
+      </change>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
     <input type="dropdown" token="worker_group" searchWhenChanged="true">
       <label>Worker Group / Single</label>
       <choice value="all_instances">All Instances</choice>
@@ -21,7 +42,7 @@
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>worker_group</fieldForValue>
       <search>
-        <query>| `dashboard_worker_group_filter`</query>
+        <query>| `dashboard_worker_group_filter($environment_filter|s$)`</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
@@ -50,12 +71,12 @@
       <default>all_instances</default>
       <initialValue>all_instances</initialValue>
     </input>
-    <input type="dropdown" token="host">
+    <input type="dropdown" token="host" searchWhenChanged="true">
       <label>Host</label>
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| `dashboard_host_filter($worker_group_event_filter|s$)`</query>
+        <query>| `dashboard_host_filter("$environment_filter|s$ $worker_group_event_filter|s$")`</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>
@@ -130,9 +151,11 @@
         <fieldForLabel>output</fieldForLabel>
         <fieldForValue>output</fieldForValue>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("total.out_events")`) WHERE `set_cribl_metrics_index` $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value` 
+          <query>| mstats sum(`set_cribl_metrics_prefix("total.out_events")`) WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value` 
 | search $worker_group_metric_filter$
 | dedup output</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
         </search>
       </input>
     </panel>
@@ -141,15 +164,15 @@
     <panel>
       <chart>
         <title>Total Events Out</title>
-        <search base="annotation_search" type="annotation"></search>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("total.out_events")`) AS out_events WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ $output_token$ $mstats_span$ BY output group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats sum(`set_cribl_metrics_prefix("total.out_events")`) AS out_events WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $output_token$ $mstats_span$ BY output group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | timechart sum("out_events") $timechart_span$ useother=false BY output WHERE max in top5
 | fields - _span*</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Event Count</option>
         <option name="charting.chart">line</option>
@@ -163,15 +186,15 @@
     <panel>
       <chart>
         <title>Total Bytes Out</title>
-        <search base="annotation_search" type="annotation"></search>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("total.out_bytes")`) AS out_bytes  WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ $output_token$ $mstats_span$ BY output group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats sum(`set_cribl_metrics_prefix("total.out_bytes")`) AS out_bytes  WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $output_token$ $mstats_span$ BY output group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | timechart sum("out_bytes") $timechart_span$ useother=false BY output WHERE max in top5
 | fields - _span*</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Bytes</option>
         <option name="charting.chart">line</option>
@@ -195,11 +218,11 @@
         <fieldForLabel>input</fieldForLabel>
         <fieldForValue>input</fieldForValue>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("total.in_events")`) WHERE `set_cribl_metrics_index` $worker_group_metric_pre_filter$ BY input group fillnull_value=`set_unknown_worker_group_value` 
+          <query>| mstats sum(`set_cribl_metrics_prefix("total.in_events")`) WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY input group fillnull_value=`set_unknown_worker_group_value` 
 | search $worker_group_metric_filter$
 | dedup input</query>
-          <earliest>-24h@h</earliest>
-          <latest>now</latest>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
         </search>
         <default>*</default>
       </input>
@@ -240,15 +263,15 @@
     <panel>
       <chart>
         <title>Total Events In</title>
-        <search base="annotation_search" type="annotation"></search>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("total.in_events")`) AS in_events  WHERE `set_cribl_metrics_index` $worker_group_metric_pre_filter$ $input_token$ $mstats_span$ BY $splitby$ group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats sum(`set_cribl_metrics_prefix("total.in_events")`) AS in_events WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $input_token$ $mstats_span$ BY $splitby$ group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | timechart sum("in_events") $timechart_span$ useother=false BY $splitby$ WHERE max in top$limit$
 | fields - _span*</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Event Count</option>
         <option name="charting.chart">line</option>
@@ -262,14 +285,14 @@
     <panel>
       <chart>
         <title>CPU Percentage by Worker Process</title>
-        <search base="annotation_search" type="annotation"></search>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("system.cpu_perc")`) AS cpu_perc WHERE `set_cribl_metrics_index` $mstats_span$ BY cribl_wp
+          <query>| mstats sum(`set_cribl_metrics_prefix("system.cpu_perc")`) AS cpu_perc WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $mstats_span$ BY cribl_wp
 | timechart sum("cpu_perc") $timechart_span$ useother=false BY cribl_wp WHERE max in top$limit$
 | fields - _span*</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">CPU %</option>
         <option name="charting.chart">line</option>
@@ -283,15 +306,15 @@
     <panel>
       <chart>
         <title>Total Bytes In</title>
-        <search base="annotation_search" type="annotation"></search>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("total.in_bytes")`) AS in_bytes  WHERE `set_cribl_metrics_index` $worker_group_metric_pre_filter$ $input_token$ $mstats_span$ BY $splitby$ group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats sum(`set_cribl_metrics_prefix("total.in_bytes")`) AS in_bytes  WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $input_token$ $mstats_span$ BY $splitby$ group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | timechart sum("in_bytes") $timechart_span$ useother=false BY $splitby$ WHERE max in top$limit$
 | fields - _span*</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Bytes</option>
         <option name="charting.chart">line</option>

--- a/criblvision/default/data/ui/views/health_check.xml
+++ b/criblvision/default/data/ui/views/health_check.xml
@@ -12,6 +12,27 @@
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="environment" searchWhenChanged="true">
+      <label>Environment</label>
+      <choice value="*">All Environments</choice>
+      <fieldForLabel>environment</fieldForLabel>
+      <fieldForValue>hosts</fieldForValue>
+      <search>
+        <query>| `dashboard_cribl_environment_filter`</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition label="All Environments">
+          <set token="environment_filter"></set>
+        </condition>
+        <condition>
+          <set token="environment_filter">host IN ($environment$)</set>
+        </condition>
+      </change>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
     <input type="dropdown" token="worker_group" searchWhenChanged="true">
       <label>Worker Group / Single</label>
       <choice value="all_instances">All Instances</choice>
@@ -20,7 +41,7 @@
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>worker_group</fieldForValue>
       <search>
-        <query>| `dashboard_worker_group_filter`</query>
+        <query>| `dashboard_worker_group_filter($environment_filter|s$)`</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
@@ -54,7 +75,7 @@
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| `dashboard_host_filter($worker_group_event_filter|s$)`</query>
+        <query>| `dashboard_host_filter($environment_filter|s$ $worker_group_event_filter|s$)`</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>
@@ -108,7 +129,7 @@
           <done>
             <set token="max_cpuPerc">$result.max_cpuPerc$</set>
           </done>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
 | stats avg(cpuPerc) AS cpuPerc</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -144,7 +165,7 @@
           <done>
             <eval token="max_memRss">tostring($result.max_memRss$, "commas")</eval>
           </done>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
 | stats avg(mem.rss) AS memRss</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -179,7 +200,7 @@
       <title>CPU Perc (Avg) Breakdown by Host over Time</title>
       <chart>
         <search depends="$show_cpu_perc$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
 | timechart avg(cpuPerc) BY host</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -198,7 +219,7 @@
       <title>CPU Perc (Avg) Breakdown by Host</title>
       <table>
         <search depends="$show_cpu_perc$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
 | stats avg(cpuPerc) AS cpuPerc BY host worker_group
 | rename host AS Host worker_group AS Group cpuPerc AS "Avg CPU %"</query>
           <earliest>$time.earliest$</earliest>
@@ -224,7 +245,7 @@
       <title>Memory Usage (Avg) Breakdown by Host over Time</title>
       <chart>
         <search depends="$show_mem_usage$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
 | timechart avg(mem.rss) BY host</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -243,7 +264,7 @@
       <title>Memory Usage (Avg) Breakdown by Host</title>
       <table>
         <search depends="$show_mem_usage$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
 | stats avg(mem.rss) AS memRss BY host worker_group
 | rename host AS Host worker_group AS Group memRss AS "Memory Usage"</query>
           <earliest>$time.earliest$</earliest>
@@ -268,7 +289,7 @@
           <done>
             <set token="unhealthy_sources">$result.unhealthy_sources$</set>
           </done>
-          <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS health WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY input group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY input group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$ health &gt; 0
 | stats count AS unhealthy_sources_count values(input) AS unhealthy_sources
 | eval unhealthy_sources = if(unhealthy_sources_count == 0, "input!=*", "input IN (\"".mvjoin(unhealthy_sources, "\", \"")."\")")</query>
@@ -293,7 +314,7 @@
           <done>
             <set token="unhealthy_destinations">$result.unhealthy_destinations$</set>
           </done>
-          <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS health WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$ health &gt; 0
 | stats count AS unhealthy_destinations_count values(output) AS unhealthy_destinations
 | eval unhealthy_destinations = if(unhealthy_destinations_count == 0, "output!=*", "output IN (\"".mvjoin(unhealthy_destinations, "\", \"")."\")")</query>
@@ -314,7 +335,7 @@
       <title>Cluster Communication Errors</title>
       <single>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=clustercomm level=warn OR level=error NOT message=metric*
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=clustercomm level=warn OR level=error NOT message=metric*
 | stats count AS cluster_communication_errors</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -337,7 +358,7 @@
             <eval token="pq_configured">if($job.resultCount$ == 0, null(), "true")</eval>
             <eval token="pq_not_configured">if($job.resultCount$ == 0, "true", null())</eval>
           </done>
-          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS total_pq_size WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS total_pq_size WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | stats sum(total_pq_size) AS total_pq_size</query>
           <earliest>-15m</earliest>
@@ -400,7 +421,7 @@
       <title>Unhealthy Sources over Time</title>
       <chart>
         <search depends="$show_unhealthy_sources$">
-          <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS health WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ $unhealthy_sources$ span=auto BY input group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $unhealthy_sources$ span=auto BY input group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | timechart max(health) BY input</query>
           <earliest>$time.earliest$</earliest>
@@ -423,7 +444,7 @@
       <title>Unhealthy Sources Breakdown</title>
       <table>
         <search depends="$show_unhealthy_sources$">
-          <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS health WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ $unhealthy_sources$ span=auto BY input host group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $unhealthy_sources$ span=auto BY input host group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | stats sparkline(max(health)) AS sparkline BY input host group
 | rex field=input "(?&lt;technology&gt;[^:]+):(?&lt;input&gt;.*)" 
@@ -457,7 +478,7 @@
       <title>Unhealthy Destinations over Time</title>
       <chart>
         <search depends="$show_unhealthy_destinations$">
-          <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS health WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ $unhealthy_destinations$ span=auto BY output group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $unhealthy_destinations$ span=auto BY output group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | timechart max(health) BY output</query>
           <earliest>$time.earliest$</earliest>
@@ -480,7 +501,7 @@
       <title>Unhealthy Destinations Breakdown</title>
       <table>
         <search depends="$show_unhealthy_destinations$">
-          <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS health WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ $unhealthy_destinations$ span=auto BY output host group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $unhealthy_destinations$ span=auto BY output host group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | stats sparkline(max(health)) AS sparkline BY output host group
 | rex field=output "(?&lt;technology&gt;[^:]+):(?&lt;output&gt;.*)" 
@@ -501,7 +522,7 @@
       <title>Cluster Communication Errors Breakdown</title>
       <table>
         <search depends="$show_cluster_communication_errors$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=clustercomm level=warn OR level=error NOT message=metric*
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=clustercomm level=warn OR level=error NOT message=metric*
 | stats count BY host worker_group
 | rename host AS Host worker_group AS Group count AS "Cluster Communication Errors"</query>
           <earliest>$time.earliest$</earliest>
@@ -530,7 +551,7 @@
       <title>PQ Size by Host (Last 15 Minutes)</title>
       <chart>
         <search depends="$show_total_pq_size$">
-          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ span=auto BY host prestats=true
+          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ span=auto BY host prestats=true
 | timechart sum(`set_cribl_metrics_prefix("pq.queue_size")`) BY host</query>
           <earliest>-15m</earliest>
           <latest>now</latest>
@@ -550,7 +571,7 @@
       <title>Historic Total PQ Size by Host (Last 15 Minutes)</title>
       <table>
         <search depends="$show_total_pq_size$">
-          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS total_pq_size WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY host group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS total_pq_size WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY host group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | rename host AS Host group AS Group total_pq_size AS "Total PQ Size"</query>
           <earliest>-15m</earliest>
@@ -573,7 +594,7 @@
       <title>Worker Process Restarts</title>
       <single>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=cribl* message="restarting worker process"
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=cribl* message="restarting worker process"
 | stats count AS worker_process_restarts</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -610,7 +631,7 @@
           <done>
             <eval token="max_back_pressured">tostring($result.max_back_pressured$, "commas")</eval>
           </done>
-          <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) AS back_pressured WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) AS back_pressured WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$ back_pressured &gt; 0
 | stats count AS back_pressured_destinations</query>
           <earliest>$time.earliest$</earliest>
@@ -631,7 +652,7 @@
       <title>Blocked Destinations</title>
       <single>
         <search>
-          <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) AS blocked WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) AS blocked WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$ blocked &gt; 0
 | stats count AS blocked_destinations</query>
           <earliest>$time.earliest$</earliest>
@@ -651,7 +672,7 @@
       <title>Destinations with PQ Engaged (Last 15 Minutes)</title>
       <single>
         <search>
-          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) as pq_engaged WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY output
+          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) as pq_engaged WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output
 | search pq_engaged &gt; 0
 | stats count AS pq_engaged</query>
           <earliest>-15m</earliest>
@@ -689,7 +710,7 @@
       <title>Worker Process Restarts by Host over Time</title>
       <chart>
         <search depends="$show_worker_process_restarts$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=cribl* message="restarting worker process" 
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=cribl* message="restarting worker process" 
 | timechart count BY host</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -709,7 +730,7 @@
       <title>Worker Process Restarts by Host</title>
       <table>
         <search depends="$show_worker_process_restarts$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=cribl* message="restarting worker process" 
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=cribl* message="restarting worker process" 
 | stats count sparkline BY host
 | rename host AS Host count AS "Worker Restarts" sparkline AS Sparkline</query>
           <earliest>$time.earliest$</earliest>
@@ -725,7 +746,7 @@
       <title>Destinations with Backpressure over Time</title>
       <chart>
         <search depends="$show_backpressured_destinations$">
-          <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) AS back_pressured WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY output group span=auto fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) AS back_pressured WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group span=auto fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$ back_pressured!=0
 | timechart max(back_pressured) BY output</query>
           <earliest>$time.earliest$</earliest>
@@ -747,7 +768,7 @@
       <title>Destinations with Backpressure Breakdown</title>
       <table>
         <search depends="$show_backpressured_destinations$">
-          <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) AS back_pressured WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY output host group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) AS back_pressured WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output host group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$ back_pressured &gt; 0
 | rex field=output "(?&lt;technology&gt;[^:]+):(?&lt;output&gt;.*)" 
 | table technology output host group
@@ -768,7 +789,7 @@
       <title>Blocked Destinations over Time</title>
       <chart>
         <search depends="$show_blocked_destinations$">
-          <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) AS blocked WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY output group span=auto fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) AS blocked WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group span=auto fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$ blocked!=0
 | timechart max(blocked) BY output</query>
           <earliest>$time.earliest$</earliest>
@@ -791,7 +812,7 @@
       <title>Blocked Destinations Breakdown</title>
       <table>
         <search depends="$show_blocked_destinations$">
-          <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) AS blocked WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY output host group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) AS blocked WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output host group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$ blocked &gt; 0
 | rex field=output "(?&lt;technology&gt;[^:]+):(?&lt;output&gt;.*)" 
 | table technology output host group
@@ -812,7 +833,7 @@
       <title>Destinations with PQ Engaged over Time (Last 15 Minutes)</title>
       <chart>
         <search depends="$show_pq_engaged$">
-          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_engaged WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY output host group span=auto fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_engaged WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output host group span=auto fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | eval pq_engaged = min(pq_engaged, 1)
 | timechart max(pq_engaged) BY output</query>
@@ -834,7 +855,7 @@
       <title>Destinations with PQ Engaged Breakdown (Last 15 Minutes)</title>
       <table>
         <search depends="$show_pq_engaged$">
-          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_engaged WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY output host group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_engaged WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output host group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | rex field=output "(?&lt;technology&gt;[^:]+):(?&lt;output&gt;.*)" 
 | table technology output host group

--- a/criblvision/default/data/ui/views/home.xml
+++ b/criblvision/default/data/ui/views/home.xml
@@ -1,5 +1,9 @@
 <form theme="dark" version="1.1">
-  <label>Log Analytics</label>
+  <label>Health Check</label>
+  <search id="annotation_search" ref="Deployment Annotations">
+    <earliest>$time.earliest$</earliest>
+    <latest>$time.latest$</latest>
+  </search>
   <fieldset submitButton="true" autoRun="false">
     <input type="time" token="time" searchWhenChanged="true">
       <label>Time Range</label>
@@ -8,34 +12,59 @@
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="environment" searchWhenChanged="true">
+      <label>Environment</label>
+      <choice value="*">All Environments</choice>
+      <fieldForLabel>environment</fieldForLabel>
+      <fieldForValue>hosts</fieldForValue>
+      <search>
+        <query>| `dashboard_cribl_environment_filter`</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition label="All Environments">
+          <set token="environment_filter"></set>
+        </condition>
+        <condition>
+          <set token="environment_filter">host IN ($environment$)</set>
+        </condition>
+      </change>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
     <input type="dropdown" token="worker_group" searchWhenChanged="true">
-      <label>Instance Type</label>
+      <label>Worker Group / Single</label>
       <choice value="all_instances">All Instances</choice>
-      <choice value="all_leaders">All Leaders</choice>
       <choice value="all_worker_groups">All Worker Groups</choice>
       <choice value="all_single">All Single Instances</choice>
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>worker_group</fieldForValue>
       <search>
-        <query>| `dashboard_worker_group_filter`</query>
+        <query>| `dashboard_worker_group_filter($environment_filter|s$)`</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
       <change>
         <condition label="All Instances">
-          <set token="worker_group_event_filter">instance_type=*</set>
-        </condition>
-        <condition label="All Leaders">
-          <set token="worker_group_event_filter">instance_type=leader</set>
+          <set token="worker_group_event_filter">instance_type IN (worker, single)</set>
+          <set token="worker_group_metric_pre_filter"></set>
+          <set token="worker_group_metric_filter">group=*</set>
         </condition>
         <condition label="All Worker Groups">
           <set token="worker_group_event_filter">instance_type=worker</set>
+          <set token="worker_group_metric_pre_filter">group=*</set>
+          <set token="worker_group_metric_filter">group=*</set>
         </condition>
         <condition label="All Single Instances">
           <set token="worker_group_event_filter">instance_type=single</set>
+          <set token="worker_group_metric_pre_filter"></set>
+          <set token="worker_group_metric_filter">group=`set_unknown_worker_group_value`</set>
         </condition>
         <condition>
           <set token="worker_group_event_filter">instance_type=worker worker_group="$worker_group$"</set>
+          <set token="worker_group_metric_pre_filter">group="$worker_group$"</set>
+          <set token="worker_group_metric_filter">group="$worker_group$"</set>
         </condition>
       </change>
       <default>all_instances</default>
@@ -46,7 +75,7 @@
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| `dashboard_host_filter($worker_group_event_filter|s$)`</query>
+        <query>| `dashboard_host_filter($environment_filter|s$ $worker_group_event_filter|s$)`</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>
@@ -56,20 +85,6 @@
       <prefix>host="</prefix>
       <suffix>"</suffix>
     </input>
-    <input type="dropdown" token="debug">
-      <label>Show Debug?</label>
-      <choice value="yes">Yes!</choice>
-      <choice value="no">No!</choice>
-      <default>no</default>
-      <change>
-        <condition value="no">
-          <unset token="show_debug"></unset>
-        </condition>
-        <condition value="yes">
-          <set token="show_debug">true</set>
-        </condition>
-      </change>
-    </input>
     <input type="link" token="how_to_use">
       <label>How to Use</label>
       <choice value="show">Show</choice>
@@ -77,190 +92,783 @@
       <default>hide</default>
       <initialValue>hide</initialValue>
       <change>
-        <condition label="Show">
-          <set token="show_details">true</set>
-        </condition>
-        <condition>
-          <unset token="show_details"></unset>
-        </condition>
+        <eval token="show_details">if(label == "Show", "true", null())</eval>
       </change>
     </input>
   </fieldset>
+  <row depends="$HIDE_CSS$">
+    <panel>
+      <html>
+        <style>
+          #cpu_perc_timeline, #mem_usage_timeline, #total_pq_size_timeline, #worker_process_reset_timeline, #backpressured_destinations_timeline, #blocked_destinations_timeline, #pq_engaged_timeline {
+            width: 65% !important;
+          }
+          #cpu_perc_breakdown, #mem_usage_breakdown, #total_pq_size_breakdown, #worker_process_reset_breakdown, #backpressured_destinations_breakdown, #blocked_destinations_breakdown, #pq_engaged_breakdown {
+            width: 35% !important;
+          }
+        </style>
+      </html>
+    </panel>
+  </row>
   <row>
     <panel depends="$show_details$">
       <html>
         <div style="font-family: Arial; font-size: 11pt; list-style-type: square; text-align: center;">
-          <p>This dashboard is interactive and intended for general troubleshooting. It displays a series of panels with <code>log_level</code> counts split by <code>channel</code> or <code>message</code>. You can refine the panel results further by limiting the log type, which defaults to <code>All</code>. Clicking on any of the <code>channel</code> or <code>message</code> values in the panels will populate a results table below with the raw messages in syntax highlighted mode.</p>
+          <p>This view is designed to provide an "at a glance" overview of the health status of the selected Worker Group(s), Single instances, or individual Nodes (via "Worker Group / Single" and "Host" dropdowns). It displays key indicators for Sources and Destinations along with CPU and memory usage for the selected host. Click on any of the high-level panels to drill down further.</p>
+          <p>
+            <b>Note:</b> This dashboard requires both logs and metrics for every panel to populate.</p>
         </div>
       </html>
     </panel>
   </row>
   <row>
     <panel>
-      <title>ERRORS</title>
-      <input type="dropdown" token="messagesplit" searchWhenChanged="true">
-        <label>Split By</label>
-        <choice value="channel">Channel</choice>
-        <choice value="message">Message</choice>
-        <default>channel</default>
-        <initialValue>channel</initialValue>
-      </input>
-      <input type="dropdown" token="logtype" searchWhenChanged="true">
-        <label>Log Type</label>
-        <choice value="api">Api</choice>
-        <choice value="w*">Worker</choice>
-        <choice value="*">All</choice>
-        <choice value="cfg*">Config events</choice>
-        <default>*</default>
-        <initialValue>*</initialValue>
-      </input>
-      <table>
+      <title>CPU Perc (Avg)</title>
+      <single>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ level=ERROR cid=$logtype$ | chart count sparkline by $messagesplit$ | sort -count | rename channel AS Channel message AS Message count AS Count sparkline AS Sparkline</query>
+          <done>
+            <set token="max_cpuPerc">$result.max_cpuPerc$</set>
+          </done>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
+| stats avg(cpuPerc) AS cpuPerc</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <option name="drilldown">cell</option>
-        <option name="percentagesRow">false</option>
+        <option name="colorBy">value</option>
+        <option name="colorMode">none</option>
+        <option name="drilldown">all</option>
+        <option name="numberPrecision">0.00</option>
+        <option name="rangeColors">["0x53a051","0xdc4e41"]</option>
+        <option name="rangeValues">[90]</option>
         <option name="refresh.display">progressbar</option>
-        <format type="number" field="Count">
-          <option name="precision">0</option>
-        </format>
+        <option name="showSparkline">1</option>
+        <option name="showTrendIndicator">1</option>
+        <option name="trellis.enabled">0</option>
+        <option name="trellis.scales.shared">1</option>
+        <option name="trellis.size">medium</option>
+        <option name="trendColorInterpretation">standard</option>
+        <option name="trendDisplayMode">absolute</option>
+        <option name="unit">%</option>
+        <option name="unitPosition">after</option>
+        <option name="useColors">1</option>
+        <option name="useThousandSeparators">1</option>
         <drilldown>
-          <set token="level">ERROR</set>
-          <set token="name">$messagesplit$</set>
-          <set token="value">$click.value$</set>
-          <set token="cid">$logtype$</set>
+          <set token="show_cpu_perc">true</set>
+          <unset token="show_mem_usage"></unset>
         </drilldown>
-      </table>
+      </single>
     </panel>
     <panel>
-      <title>WARNS</title>
-      <input type="dropdown" token="messagesplit1" searchWhenChanged="true">
-        <label>Split By</label>
-        <choice value="channel">Channel</choice>
-        <choice value="message">Message</choice>
-        <default>channel</default>
-        <initialValue>channel</initialValue>
-      </input>
-      <input type="dropdown" token="logtype1" searchWhenChanged="true">
-        <label>Log Type</label>
-        <choice value="api">Api</choice>
-        <choice value="w*">Worker</choice>
-        <choice value="*">All</choice>
-        <choice value="cfg*">Config events</choice>
-        <default>*</default>
-        <initialValue>*</initialValue>
-      </input>
-      <table>
+      <title>Memory Usage (Avg)</title>
+      <single>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ level=WARN cid=$logtype1$ | chart count sparkline by $messagesplit1$ | sort -count | rename channel AS Channel message AS Message count AS Count sparkline AS Sparkline</query>
+          <done>
+            <eval token="max_memRss">tostring($result.max_memRss$, "commas")</eval>
+          </done>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
+| stats avg(mem.rss) AS memRss</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <option name="drilldown">cell</option>
+        <option name="colorBy">value</option>
+        <option name="colorMode">none</option>
+        <option name="drilldown">all</option>
+        <option name="numberPrecision">0.00</option>
+        <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
+        <option name="rangeValues">[0,30,70,100]</option>
         <option name="refresh.display">progressbar</option>
-        <format type="number" field="Count">
-          <option name="precision">0</option>
-        </format>
+        <option name="showSparkline">1</option>
+        <option name="showTrendIndicator">1</option>
+        <option name="trellis.enabled">0</option>
+        <option name="trellis.scales.shared">1</option>
+        <option name="trellis.size">medium</option>
+        <option name="trendColorInterpretation">standard</option>
+        <option name="trendDisplayMode">absolute</option>
+        <option name="unit">MB</option>
+        <option name="unitPosition">after</option>
+        <option name="useColors">0</option>
+        <option name="useThousandSeparators">1</option>
         <drilldown>
-          <set token="level">WARN</set>
-          <set token="name">$messagesplit$</set>
-          <set token="value">$click.value$</set>
-          <set token="cid">$logtype1$</set>
+          <set token="show_mem_usage">true</set>
+          <unset token="show_cpu_perc"></unset>
         </drilldown>
-      </table>
+      </single>
     </panel>
-    <panel>
-      <title>INFO</title>
-      <input type="dropdown" token="messagesplit2" searchWhenChanged="true">
-        <label>Split By</label>
-        <choice value="channel">Channel</choice>
-        <choice value="message">Message</choice>
-        <default>channel</default>
-        <initialValue>channel</initialValue>
-      </input>
-      <input type="dropdown" token="logtype2" searchWhenChanged="true">
-        <label>Log Type</label>
-        <choice value="api">Api</choice>
-        <choice value="w*">Worker</choice>
-        <choice value="*">All</choice>
-        <choice value="cfg*">Config events</choice>
-        <default>*</default>
-        <initialValue>*</initialValue>
-      </input>
+  </row>
+  <row depends="$show_cpu_perc$">
+    <panel id="cpu_perc_timeline">
+      <title>CPU Perc (Avg) Breakdown by Host over Time</title>
+      <chart>
+        <search depends="$show_cpu_perc$">
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
+| timechart avg(cpuPerc) BY host</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <search base="annotation_search" type="annotation"></search>
+        <option name="charting.axisTitleX.text">Time</option>
+        <option name="charting.axisTitleY.text">Avg CPU (%)</option>
+        <option name="charting.chart">area</option>
+        <option name="charting.chart.nullValueMode">connect</option>
+        <option name="charting.drilldown">none</option>
+        <option name="charting.legend.placement">bottom</option>
+        <option name="refresh.display">progressbar</option>
+      </chart>
+    </panel>
+    <panel id="cpu_perc_breakdown">
+      <title>CPU Perc (Avg) Breakdown by Host</title>
       <table>
-        <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ level=INFO cid=$logtype2$ | chart count sparkline by $messagesplit2$ | sort -count | rename channel AS Channel message AS Message count AS Count sparkline AS Sparkline</query>
+        <search depends="$show_cpu_perc$">
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
+| stats avg(cpuPerc) AS cpuPerc BY host worker_group
+| rename host AS Host worker_group AS Group cpuPerc AS "Avg CPU %"</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
         <option name="drilldown">cell</option>
         <option name="refresh.display">progressbar</option>
-        <format type="number" field="Count">
-          <option name="precision">0</option>
+        <format type="number" field="Avg CPU %">
+          <option name="unit">%</option>
+        </format>
+        <format type="color" field="Avg CPU %">
+          <colorPalette type="list">[#118832,#D94E17,#D41F1F]</colorPalette>
+          <scale type="threshold">90,100</scale>
         </format>
         <drilldown>
-          <set token="level">INFO</set>
-          <set token="name">$messagesplit2$</set>
-          <set token="value">$click.value$</set>
-          <set token="cid">$logtype2$</set>
-        </drilldown>
-      </table>
-    </panel>
-    <panel depends="$show_debug$">
-      <title>DEBUG</title>
-      <input type="dropdown" token="messagesplit3" searchWhenChanged="true">
-        <label>Split By</label>
-        <choice value="channel">Channel</choice>
-        <choice value="message">Message</choice>
-        <default>channel</default>
-        <initialValue>channel</initialValue>
-      </input>
-      <input type="dropdown" token="logtype3" searchWhenChanged="true">
-        <label>Log Type</label>
-        <choice value="api">Api</choice>
-        <choice value="w*">Worker</choice>
-        <choice value="*">All</choice>
-        <choice value="cfg*">Config events</choice>
-        <default>*</default>
-        <initialValue>*</initialValue>
-      </input>
-      <table>
-        <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ level=DEBUG cid=$logtype3$ | chart count sparkline by $messagesplit3$ | sort -count | rename channel AS Channel message AS Message count AS Count sparkline AS Sparkline</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <option name="drilldown">cell</option>
-        <option name="percentagesRow">false</option>
-        <option name="refresh.display">progressbar</option>
-        <format type="number" field="Count">
-          <option name="precision">0</option>
-        </format>
-        <drilldown>
-          <set token="level">DEBUG</set>
-          <set token="name">$messagesplit3$</set>
-          <set token="value">$click.value$</set>
-          <set token="cid">$logtype3$</set>
+          <link target="_blank">/app/criblvision/stats?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.host=$row.Host$</link>
         </drilldown>
       </table>
     </panel>
   </row>
-  <row depends="$name$">
-    <panel>
-      <event>
-        <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ $name$=$value|s$ cid=$cid$ level=$level$</query>
+  <row depends="$show_mem_usage$">
+    <panel id="mem_usage_timeline">
+      <title>Memory Usage (Avg) Breakdown by Host over Time</title>
+      <chart>
+        <search depends="$show_mem_usage$">
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
+| timechart avg(mem.rss) BY host</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <option name="list.drilldown">full</option>
+        <search base="annotation_search" type="annotation"></search>
+        <option name="charting.axisTitleX.text">Time</option>
+        <option name="charting.axisTitleY.text">Avg Memory Usage (MB)</option>
+        <option name="charting.chart">area</option>
+        <option name="charting.chart.nullValueMode">connect</option>
+        <option name="charting.drilldown">none</option>
+        <option name="charting.legend.placement">bottom</option>
+        <option name="refresh.display">progressbar</option>
+      </chart>
+    </panel>
+    <panel id="mem_usage_breakdown">
+      <title>Memory Usage (Avg) Breakdown by Host</title>
+      <table>
+        <search depends="$show_mem_usage$">
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
+| stats avg(mem.rss) AS memRss BY host worker_group
+| rename host AS Host worker_group AS Group memRss AS "Memory Usage"</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="drilldown">cell</option>
+        <option name="refresh.display">progressbar</option>
+        <format type="number" field="Memory Usage">
+          <option name="unit">MB</option>
+        </format>
+        <drilldown>
+          <link target="_blank">/app/criblvision/stats?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.host=$row.Host$</link>
+        </drilldown>
+      </table>
+    </panel>
+  </row>
+  <row>
+    <panel>
+      <title>Unhealthy Sources</title>
+      <single>
+        <search>
+          <done>
+            <set token="unhealthy_sources">$result.unhealthy_sources$</set>
+          </done>
+          <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY input group fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$ health &gt; 0
+| stats count AS unhealthy_sources_count values(input) AS unhealthy_sources
+| eval unhealthy_sources = if(unhealthy_sources_count == 0, "input!=*", "input IN (\"".mvjoin(unhealthy_sources, "\", \"")."\")")</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="drilldown">all</option>
+        <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
         <option name="refresh.display">progressbar</option>
         <drilldown>
-          <link target="_blank">search?q=%60set_cribl_internal_log_index%60%20source%3D*.log%20$name$%3D$value|s$%20level%3D$level$&amp;earliest=$time.earliest$&amp;latest=$time.latest$</link>
+          <set token="show_unhealthy_sources">true</set>
+          <unset token="show_unhealthy_destinations"></unset>
+          <unset token="show_cluster_communication_errors"></unset>
+          <unset token="show_total_pq_size"></unset>
         </drilldown>
-      </event>
+      </single>
+    </panel>
+    <panel>
+      <title>Unhealthy Destinations</title>
+      <single>
+        <search>
+          <done>
+            <set token="unhealthy_destinations">$result.unhealthy_destinations$</set>
+          </done>
+          <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$ health &gt; 0
+| stats count AS unhealthy_destinations_count values(output) AS unhealthy_destinations
+| eval unhealthy_destinations = if(unhealthy_destinations_count == 0, "output!=*", "output IN (\"".mvjoin(unhealthy_destinations, "\", \"")."\")")</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="drilldown">all</option>
+        <option name="refresh.display">progressbar</option>
+        <drilldown>
+          <set token="show_unhealthy_destinations">true</set>
+          <unset token="show_unhealthy_sources"></unset>
+          <unset token="show_cluster_communication_errors"></unset>
+          <unset token="show_total_pq_size"></unset>
+        </drilldown>
+      </single>
+    </panel>
+    <panel>
+      <title>Cluster Communication Errors</title>
+      <single>
+        <search>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=clustercomm level=warn OR level=error NOT message=metric*
+| stats count AS cluster_communication_errors</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="drilldown">all</option>
+        <option name="refresh.display">progressbar</option>
+        <drilldown>
+          <set token="show_cluster_communication_errors">true</set>
+          <unset token="show_unhealthy_sources"></unset>
+          <unset token="show_unhealthy_destinations"></unset>
+          <unset token="show_total_pq_size"></unset>
+        </drilldown>
+      </single>
+    </panel>
+    <panel depends="$pq_configured$">
+      <title>Historic Total PQ Size (Last 15 Minutes)</title>
+      <single>
+        <search>
+          <done>
+            <eval token="pq_configured">if($job.resultCount$ == 0, null(), "true")</eval>
+            <eval token="pq_not_configured">if($job.resultCount$ == 0, "true", null())</eval>
+          </done>
+          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS total_pq_size WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY group fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$
+| stats sum(total_pq_size) AS total_pq_size</query>
+          <earliest>-15m</earliest>
+          <latest>now</latest>
+          <sampleRatio>1</sampleRatio>
+        </search>
+        <option name="colorBy">value</option>
+        <option name="colorMode">none</option>
+        <option name="drilldown">all</option>
+        <option name="numberPrecision">0</option>
+        <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
+        <option name="rangeValues">[0,30,70,100]</option>
+        <option name="refresh.display">progressbar</option>
+        <option name="showSparkline">1</option>
+        <option name="showTrendIndicator">1</option>
+        <option name="trellis.enabled">0</option>
+        <option name="trellis.scales.shared">1</option>
+        <option name="trellis.size">medium</option>
+        <option name="trendColorInterpretation">standard</option>
+        <option name="trendDisplayMode">absolute</option>
+        <option name="unit">B</option>
+        <option name="unitPosition">after</option>
+        <option name="useColors">0</option>
+        <option name="useThousandSeparators">1</option>
+        <drilldown>
+          <set token="show_total_pq_size">true</set>
+          <unset token="show_unhealthy_sources"></unset>
+          <unset token="show_unhealthy_destinations"></unset>
+          <unset token="show_cluster_communication_errors"></unset>
+        </drilldown>
+      </single>
+    </panel>
+    <panel depends="$pq_not_configured$">
+      <title>Historic Total PQ Size (Last 15 Minutes)</title>
+      <single>
+        <search>
+          <query>| makeresults | eval message = "Not Configured"</query>
+          <earliest>-1s</earliest>
+          <latest>now</latest>
+        </search>
+        <option name="refresh.display">progressbar</option>
+      </single>
+    </panel>
+  </row>
+  <row depends="$show_unhealthy_sources$">
+    <panel>
+      <html>
+        <div style="font-family: Arial; font-size: 11pt; list-style-type: square; text-align: center;">
+          <p>
+            <b>Note:</b> Hover over individual Sources in the legend to highlight them on the graph. The status values represent the health of a Source as documented in the <a href="https://docs.cribl.io/stream/internal-metrics/#health">System Health Metrics</a> section of the Cribl Docs:</p>
+            <p>0 = Healthy</p>
+            <p>1 = Warning</p>
+            <p>2 = Trouble</p>
+        </div>
+      </html>
+    </panel>
+  </row>
+  <row depends="$show_unhealthy_sources$">
+    <panel>
+      <title>Unhealthy Sources over Time</title>
+      <chart>
+        <search depends="$show_unhealthy_sources$">
+          <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $unhealthy_sources$ span=auto BY input group fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$
+| timechart max(health) BY input</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <search base="annotation_search" type="annotation"></search>
+        <option name="charting.axisLabelsY.majorUnit">1</option>
+        <option name="charting.axisTitleX.text">Time</option>
+        <option name="charting.axisTitleY.text">Status</option>
+        <option name="charting.axisY.maximumNumber">2</option>
+        <option name="charting.axisY.minimumNumber">0</option>
+        <option name="charting.chart">area</option>
+        <option name="charting.chart.nullValueMode">zero</option>
+        <option name="charting.chart.overlayFields">warning,troubled</option>
+        <option name="charting.legend.placement">bottom</option>
+        <option name="refresh.display">progressbar</option>
+      </chart>
+    </panel>
+    <panel>
+      <title>Unhealthy Sources Breakdown</title>
+      <table>
+        <search depends="$show_unhealthy_sources$">
+          <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $unhealthy_sources$ span=auto BY input host group fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$
+| stats sparkline(max(health)) AS sparkline BY input host group
+| rex field=input "(?&lt;technology&gt;[^:]+):(?&lt;input&gt;.*)" 
+| table technology input host group sparkline
+| rename technology AS Technology input AS Source host AS Host group AS Group sparkline AS "Health Sparkline"</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="refresh.display">progressbar</option>
+        <drilldown>
+          <link target="_blank">/app/criblvision/sources_and_destinations_overview?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.host=$row.Host$&amp;form.worker_group=$row.Group$&amp;form.selected=$row.Source$&amp;form.full_selected=$row.Technology$:$row.Source$&amp;form.type=in&amp;type_printable=In</link>
+        </drilldown>
+      </table>
+    </panel>
+  </row>
+  <row depends="$show_unhealthy_destinations$">
+    <panel>
+      <html>
+        <div style="font-family: Arial; font-size: 11pt; list-style-type: square; text-align: center;">
+          <p>
+            <b>Note:</b> Hover over individual Destinations in the legend to highlight them on the graph. The status values represent the health of a Destination as documented in the <a href="https://docs.cribl.io/stream/internal-metrics/#health">System Health Metrics</a> section of the Cribl Docs:</p>
+            <p>0 = Healthy</p>
+            <p>1 = Warning</p>
+            <p>2 = Trouble</p>
+        </div>
+      </html>
+    </panel>
+  </row>
+  <row depends="$show_unhealthy_destinations$">
+    <panel>
+      <title>Unhealthy Destinations over Time</title>
+      <chart>
+        <search depends="$show_unhealthy_destinations$">
+          <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $unhealthy_destinations$ span=auto BY output group fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$
+| timechart max(health) BY output</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <search base="annotation_search" type="annotation"></search>
+        <option name="charting.axisLabelsY.majorUnit">1</option>
+        <option name="charting.axisTitleX.text">Time</option>
+        <option name="charting.axisTitleY.text">Status</option>
+        <option name="charting.axisY.maximumNumber">2</option>
+        <option name="charting.axisY.minimumNumber">0</option>
+        <option name="charting.chart">area</option>
+        <option name="charting.chart.nullValueMode">zero</option>
+        <option name="charting.chart.overlayFields">warning,troubled</option>
+        <option name="charting.legend.placement">bottom</option>
+        <option name="refresh.display">progressbar</option>
+      </chart>
+    </panel>
+    <panel>
+      <title>Unhealthy Destinations Breakdown</title>
+      <table>
+        <search depends="$show_unhealthy_destinations$">
+          <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $unhealthy_destinations$ span=auto BY output host group fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$
+| stats sparkline(max(health)) AS sparkline BY output host group
+| rex field=output "(?&lt;technology&gt;[^:]+):(?&lt;output&gt;.*)" 
+| table technology output host group sparkline
+| rename technology AS Technology output AS Destination host AS Host group AS Group sparkline AS "Health Sparkline"</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="refresh.display">progressbar</option>
+        <drilldown>
+          <link target="_blank">/app/criblvision/sources_and_destinations_overview?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.host=$row.Host$&amp;form.worker_group=$row.Group$&amp;form.selected=$row.Destination$&amp;form.full_selected=$row.Technology$:$row.Destination$&amp;form.type=out&amp;type_printable=Out</link>
+        </drilldown>
+      </table>
+    </panel>
+  </row>
+  <row depends="$show_cluster_communication_errors$">
+    <panel>
+      <title>Cluster Communication Errors Breakdown</title>
+      <table>
+        <search depends="$show_cluster_communication_errors$">
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=clustercomm level=warn OR level=error NOT message=metric*
+| stats count BY host worker_group
+| rename host AS Host worker_group AS Group count AS "Cluster Communication Errors"</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="drilldown">cell</option>
+        <option name="refresh.display">progressbar</option>
+        <drilldown>
+          <link target="_blank">search?q=%60set_cribl_internal_log_index%60%20host%3D$row.Host$%20worker_group%3D$row.Group$%20channel%3Dclustercomm%20level%3Dwarn%20OR%20level%3Derror%20NOT%20message%3Dmetric*&amp;earliest=$time.earliest$&amp;latest=$time.latest$</link>
+        </drilldown>
+      </table>
+    </panel>
+  </row>
+  <row depends="$show_total_pq_size$">
+    <panel>
+      <html>
+        <div style="font-family: Arial; font-size: 11pt; list-style-type: square; text-align: center;">
+          <p>
+            <b>Note:</b> The PQ panels are locked to showing data from the last 15 minutes to give an up-to-date view of the PQ size.</p>
+        </div>
+      </html>
+    </panel>
+  </row>
+  <row depends="$show_total_pq_size$">
+    <panel id="total_pq_size_timeline">
+      <title>PQ Size by Host (Last 15 Minutes)</title>
+      <chart>
+        <search depends="$show_total_pq_size$">
+          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ span=auto BY host prestats=true
+| timechart sum(`set_cribl_metrics_prefix("pq.queue_size")`) BY host</query>
+          <earliest>-15m</earliest>
+          <latest>now</latest>
+        </search>
+        <search base="annotation_search" type="annotation"></search>
+        <option name="charting.axisTitleX.text">Time</option>
+        <option name="charting.axisTitleY.text">PQ Size (B)</option>
+        <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">zero</option>
+        <option name="charting.chart.showDataLabels">none</option>
+        <option name="charting.drilldown">none</option>
+        <option name="charting.legend.placement">bottom</option>
+        <option name="refresh.display">progressbar</option>
+      </chart>
+    </panel>
+    <panel id="total_pq_size_breakdown">
+      <title>Historic Total PQ Size by Host (Last 15 Minutes)</title>
+      <table>
+        <search depends="$show_total_pq_size$">
+          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS total_pq_size WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY host group fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$
+| rename host AS Host group AS Group total_pq_size AS "Total PQ Size"</query>
+          <earliest>-15m</earliest>
+          <latest>now</latest>
+        </search>
+        <option name="drilldown">cell</option>
+        <option name="refresh.display">progressbar</option>
+        <format type="number" field="Total PQ Size">
+          <option name="precision">0</option>
+          <option name="unit">B</option>
+        </format>
+        <drilldown>
+          <link target="_blank">/app/criblvision/persistent_queue_analytics?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.host=$row.Host$</link>
+        </drilldown>
+      </table>
+    </panel>
+  </row>
+  <row>
+    <panel>
+      <title>Worker Process Restarts</title>
+      <single>
+        <search>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=cribl* message="restarting worker process"
+| stats count AS worker_process_restarts</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="colorBy">value</option>
+        <option name="colorMode">none</option>
+        <option name="drilldown">all</option>
+        <option name="numberPrecision">0</option>
+        <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
+        <option name="rangeValues">[0,30,70,100]</option>
+        <option name="refresh.display">progressbar</option>
+        <option name="showSparkline">1</option>
+        <option name="showTrendIndicator">1</option>
+        <option name="trellis.enabled">0</option>
+        <option name="trellis.scales.shared">1</option>
+        <option name="trellis.size">medium</option>
+        <option name="trendColorInterpretation">standard</option>
+        <option name="trendDisplayMode">absolute</option>
+        <option name="unitPosition">after</option>
+        <option name="useColors">0</option>
+        <option name="useThousandSeparators">1</option>
+        <drilldown>
+          <set token="show_worker_process_restarts">true</set>
+          <unset token="show_backpressured_destinations"></unset>
+          <unset token="show_blocked_destinations"></unset>
+          <unset token="show_pq_engaged"></unset>
+        </drilldown>
+      </single>
+    </panel>
+    <panel>
+      <title>Destinations with Backpressure</title>
+      <single>
+        <search>
+          <done>
+            <eval token="max_back_pressured">tostring($result.max_back_pressured$, "commas")</eval>
+          </done>
+          <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) AS back_pressured WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$ back_pressured &gt; 0
+| stats count AS back_pressured_destinations</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="drilldown">all</option>
+        <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
+        <option name="refresh.display">progressbar</option>
+        <drilldown>
+          <set token="show_backpressured_destinations">true</set>
+          <unset token="show_worker_process_restarts"></unset>
+          <unset token="show_blocked_destinations"></unset>
+          <unset token="show_pq_engaged"></unset>
+        </drilldown>
+      </single>
+    </panel>
+    <panel>
+      <title>Blocked Destinations</title>
+      <single>
+        <search>
+          <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) AS blocked WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$ blocked &gt; 0
+| stats count AS blocked_destinations</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="drilldown">all</option>
+        <option name="refresh.display">progressbar</option>
+        <drilldown>
+          <set token="show_blocked_destinations">true</set>
+          <unset token="show_worker_process_restarts"></unset>
+          <unset token="show_backpressured_destinations"></unset>
+          <unset token="show_pq_engaged"></unset>
+        </drilldown>
+      </single>
+    </panel>
+    <panel>
+      <title>Destinations with PQ Engaged (Last 15 Minutes)</title>
+      <single>
+        <search>
+          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) as pq_engaged WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output
+| search pq_engaged &gt; 0
+| stats count AS pq_engaged</query>
+          <earliest>-15m</earliest>
+          <latest>now</latest>
+          <sampleRatio>1</sampleRatio>
+        </search>
+        <option name="colorBy">value</option>
+        <option name="colorMode">none</option>
+        <option name="drilldown">all</option>
+        <option name="numberPrecision">0</option>
+        <option name="rangeColors">["0x53a051", "0x0877a6", "0xf8be34", "0xf1813f", "0xdc4e41"]</option>
+        <option name="rangeValues">[0,30,70,100]</option>
+        <option name="refresh.display">progressbar</option>
+        <option name="showSparkline">1</option>
+        <option name="showTrendIndicator">1</option>
+        <option name="trellis.enabled">0</option>
+        <option name="trellis.scales.shared">1</option>
+        <option name="trellis.size">medium</option>
+        <option name="trendColorInterpretation">standard</option>
+        <option name="trendDisplayMode">absolute</option>
+        <option name="unitPosition">after</option>
+        <option name="useColors">0</option>
+        <option name="useThousandSeparators">1</option>
+        <drilldown>
+          <set token="show_pq_engaged">true</set>
+          <unset token="show_worker_process_restarts"></unset>
+          <unset token="show_backpressured_destinations"></unset>
+          <unset token="show_blocked_destinations"></unset>
+        </drilldown>
+      </single>
+    </panel>
+  </row>
+  <row depends="$show_worker_process_restarts$">
+    <panel id="worker_process_reset_timeline">
+      <title>Worker Process Restarts by Host over Time</title>
+      <chart>
+        <search depends="$show_worker_process_restarts$">
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=cribl* message="restarting worker process" 
+| timechart count BY host</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <search base="annotation_search" type="annotation"></search>
+        <option name="charting.axisTitleX.text">Time</option>
+        <option name="charting.axisTitleY.text">Worker Process Restarts</option>
+        <option name="charting.chart">area</option>
+        <option name="charting.chart.nullValueMode">zero</option>
+        <option name="charting.chart.stackMode">stacked</option>
+        <option name="charting.drilldown">none</option>
+        <option name="charting.legend.placement">bottom</option>
+        <option name="refresh.display">progressbar</option>
+      </chart>
+    </panel>
+    <panel id="worker_process_reset_breakdown">
+      <title>Worker Process Restarts by Host</title>
+      <table>
+        <search depends="$show_worker_process_restarts$">
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=cribl* message="restarting worker process" 
+| stats count sparkline BY host
+| rename host AS Host count AS "Worker Restarts" sparkline AS Sparkline</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="drilldown">none</option>
+        <option name="refresh.display">progressbar</option>
+      </table>
+    </panel>
+  </row>
+  <row depends="$show_backpressured_destinations$">
+    <panel id="backpressured_destinations_timeline">
+      <title>Destinations with Backpressure over Time</title>
+      <chart>
+        <search depends="$show_backpressured_destinations$">
+          <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) AS back_pressured WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group span=auto fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$ back_pressured!=0
+| timechart max(back_pressured) BY output</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <search base="annotation_search" type="annotation"></search>
+        <option name="charting.axisTitleX.text">Time</option>
+        <option name="charting.axisTitleY.text">Back Pressure</option>
+        <option name="charting.axisY.minimumNumber">0</option>
+        <option name="charting.chart">area</option>
+        <option name="charting.chart.nullValueMode">zero</option>
+        <option name="charting.chart.stackMode">stacked</option>
+        <option name="charting.drilldown">none</option>
+        <option name="charting.legend.placement">bottom</option>
+        <option name="refresh.display">progressbar</option>
+      </chart>
+    </panel>
+    <panel id="backpressured_destinations_breakdown">
+      <title>Destinations with Backpressure Breakdown</title>
+      <table>
+        <search depends="$show_backpressured_destinations$">
+          <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) AS back_pressured WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output host group fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$ back_pressured &gt; 0
+| rex field=output "(?&lt;technology&gt;[^:]+):(?&lt;output&gt;.*)" 
+| table technology output host group
+| rename technology AS Technology output AS Destination host AS Host group AS Group</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="drilldown">cell</option>
+        <option name="refresh.display">progressbar</option>
+        <drilldown>
+          <link target="_blank">/app/criblvision/sources_and_destinations_overview?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.worker_group=$row.Group$&amp;form.host=$row.Host$&amp;form.selected=$row.Destination$&amp;form.full_selected=$row.Technology$:$row.Destination$&amp;form.type=out&amp;type_printable=Out</link>
+        </drilldown>
+      </table>
+    </panel>
+  </row>
+  <row depends="$show_blocked_destinations$">
+    <panel id="blocked_destinations_timeline">
+      <title>Blocked Destinations over Time</title>
+      <chart>
+        <search depends="$show_blocked_destinations$">
+          <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) AS blocked WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group span=auto fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$ blocked!=0
+| timechart max(blocked) BY output</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <search base="annotation_search" type="annotation"></search>
+        <option name="charting.axisTitleX.text">Time</option>
+        <option name="charting.axisTitleY.text">Back Pressure</option>
+        <option name="charting.axisY.abbreviation">none</option>
+        <option name="charting.axisY.minimumNumber">0</option>
+        <option name="charting.chart">area</option>
+        <option name="charting.chart.nullValueMode">zero</option>
+        <option name="charting.chart.stackMode">stacked</option>
+        <option name="charting.drilldown">none</option>
+        <option name="charting.legend.placement">bottom</option>
+        <option name="refresh.display">progressbar</option>
+      </chart>
+    </panel>
+    <panel id="blocked_destinations_breakdown">
+      <title>Blocked Destinations Breakdown</title>
+      <table>
+        <search depends="$show_blocked_destinations$">
+          <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) AS blocked WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output host group fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$ blocked &gt; 0
+| rex field=output "(?&lt;technology&gt;[^:]+):(?&lt;output&gt;.*)" 
+| table technology output host group
+| rename technology AS Technology output AS Destination host AS Host group AS Group</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="drilldown">cell</option>
+        <option name="refresh.display">progressbar</option>
+        <drilldown>
+          <link target="_blank">/app/criblvision/sources_and_destinations_overview?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.worker_group=$row.Group$&amp;form.host=$row.Host$&amp;form.selected=$row.Destination$&amp;form.full_selected=$row.Technology$:$row.Destination$&amp;form.type=out&amp;type_printable=Out</link>
+        </drilldown>
+      </table>
+    </panel>
+  </row>
+  <row depends="$show_pq_engaged$">
+    <panel id="pq_engaged_timeline">
+      <title>Destinations with PQ Engaged over Time (Last 15 Minutes)</title>
+      <chart>
+        <search depends="$show_pq_engaged$">
+          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_engaged WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output host group span=auto fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$
+| eval pq_engaged = min(pq_engaged, 1)
+| timechart max(pq_engaged) BY output</query>
+          <earliest>-15m</earliest>
+          <latest>now</latest>
+        </search>
+        <search base="annotation_search" type="annotation"></search>
+        <option name="charting.axisTitleX.text">Time</option>
+        <option name="charting.axisTitleY.text">PQs Engaged</option>
+        <option name="charting.chart">area</option>
+        <option name="charting.chart.nullValueMode">zero</option>
+        <option name="charting.chart.stackMode">stacked100</option>
+        <option name="charting.drilldown">none</option>
+        <option name="charting.legend.placement">bottom</option>
+        <option name="refresh.display">progressbar</option>
+      </chart>
+    </panel>
+    <panel id="pq_engaged_breakdown">
+      <title>Destinations with PQ Engaged Breakdown (Last 15 Minutes)</title>
+      <table>
+        <search depends="$show_pq_engaged$">
+          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_engaged WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output host group fillnull_value=`set_unknown_worker_group_value`
+| search $worker_group_metric_filter$
+| rex field=output "(?&lt;technology&gt;[^:]+):(?&lt;output&gt;.*)" 
+| table technology output host group
+| rename technology AS Technology output AS Destination host AS Host group AS Group</query>
+          <earliest>-15m</earliest>
+          <latest>now</latest>
+        </search>
+        <option name="drilldown">cell</option>
+        <option name="refresh.display">progressbar</option>
+        <drilldown>
+          <link target="_blank">/app/criblvision/sources_and_destinations_overview?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.worker_group=$row.Group$&amp;form.host=$row.Host$&amp;form.selected=$row.Destination$&amp;form.full_selected=$row.Technology$:$row.Destination$&amp;form.type=out&amp;type_printable=Out</link>
+        </drilldown>
+      </table>
     </panel>
   </row>
 </form>

--- a/criblvision/default/data/ui/views/home.xml
+++ b/criblvision/default/data/ui/views/home.xml
@@ -1,9 +1,5 @@
 <form theme="dark" version="1.1">
-  <label>Health Check</label>
-  <search id="annotation_search" ref="Deployment Annotations">
-    <earliest>$time.earliest$</earliest>
-    <latest>$time.latest$</latest>
-  </search>
+  <label>Log Analytics</label>
   <fieldset submitButton="true" autoRun="false">
     <input type="time" token="time" searchWhenChanged="true">
       <label>Time Range</label>
@@ -34,8 +30,9 @@
       <initialValue>*</initialValue>
     </input>
     <input type="dropdown" token="worker_group" searchWhenChanged="true">
-      <label>Worker Group / Single</label>
+      <label>Instance Type</label>
       <choice value="all_instances">All Instances</choice>
+      <choice value="all_leaders">All Leaders</choice>
       <choice value="all_worker_groups">All Worker Groups</choice>
       <choice value="all_single">All Single Instances</choice>
       <fieldForLabel>label</fieldForLabel>
@@ -47,24 +44,19 @@
       </search>
       <change>
         <condition label="All Instances">
-          <set token="worker_group_event_filter">instance_type IN (worker, single)</set>
-          <set token="worker_group_metric_pre_filter"></set>
-          <set token="worker_group_metric_filter">group=*</set>
+          <set token="worker_group_event_filter">instance_type=*</set>
+        </condition>
+        <condition label="All Leaders">
+          <set token="worker_group_event_filter">instance_type=leader</set>
         </condition>
         <condition label="All Worker Groups">
           <set token="worker_group_event_filter">instance_type=worker</set>
-          <set token="worker_group_metric_pre_filter">group=*</set>
-          <set token="worker_group_metric_filter">group=*</set>
         </condition>
         <condition label="All Single Instances">
           <set token="worker_group_event_filter">instance_type=single</set>
-          <set token="worker_group_metric_pre_filter"></set>
-          <set token="worker_group_metric_filter">group=`set_unknown_worker_group_value`</set>
         </condition>
         <condition>
           <set token="worker_group_event_filter">instance_type=worker worker_group="$worker_group$"</set>
-          <set token="worker_group_metric_pre_filter">group="$worker_group$"</set>
-          <set token="worker_group_metric_filter">group="$worker_group$"</set>
         </condition>
       </change>
       <default>all_instances</default>
@@ -85,6 +77,20 @@
       <prefix>host="</prefix>
       <suffix>"</suffix>
     </input>
+    <input type="dropdown" token="debug">
+      <label>Show Debug?</label>
+      <choice value="yes">Yes!</choice>
+      <choice value="no">No!</choice>
+      <default>no</default>
+      <change>
+        <condition value="no">
+          <unset token="show_debug"></unset>
+        </condition>
+        <condition value="yes">
+          <set token="show_debug">true</set>
+        </condition>
+      </change>
+    </input>
     <input type="link" token="how_to_use">
       <label>How to Use</label>
       <choice value="show">Show</choice>
@@ -92,783 +98,190 @@
       <default>hide</default>
       <initialValue>hide</initialValue>
       <change>
-        <eval token="show_details">if(label == "Show", "true", null())</eval>
+        <condition label="Show">
+          <set token="show_details">true</set>
+        </condition>
+        <condition>
+          <unset token="show_details"></unset>
+        </condition>
       </change>
     </input>
   </fieldset>
-  <row depends="$HIDE_CSS$">
-    <panel>
-      <html>
-        <style>
-          #cpu_perc_timeline, #mem_usage_timeline, #total_pq_size_timeline, #worker_process_reset_timeline, #backpressured_destinations_timeline, #blocked_destinations_timeline, #pq_engaged_timeline {
-            width: 65% !important;
-          }
-          #cpu_perc_breakdown, #mem_usage_breakdown, #total_pq_size_breakdown, #worker_process_reset_breakdown, #backpressured_destinations_breakdown, #blocked_destinations_breakdown, #pq_engaged_breakdown {
-            width: 35% !important;
-          }
-        </style>
-      </html>
-    </panel>
-  </row>
   <row>
     <panel depends="$show_details$">
       <html>
         <div style="font-family: Arial; font-size: 11pt; list-style-type: square; text-align: center;">
-          <p>This view is designed to provide an "at a glance" overview of the health status of the selected Worker Group(s), Single instances, or individual Nodes (via "Worker Group / Single" and "Host" dropdowns). It displays key indicators for Sources and Destinations along with CPU and memory usage for the selected host. Click on any of the high-level panels to drill down further.</p>
-          <p>
-            <b>Note:</b> This dashboard requires both logs and metrics for every panel to populate.</p>
+          <p>This dashboard is interactive and intended for general troubleshooting. It displays a series of panels with <code>log_level</code> counts split by <code>channel</code> or <code>message</code>. You can refine the panel results further by limiting the log type, which defaults to <code>All</code>. Clicking on any of the <code>channel</code> or <code>message</code> values in the panels will populate a results table below with the raw messages in syntax highlighted mode.</p>
         </div>
       </html>
     </panel>
   </row>
   <row>
     <panel>
-      <title>CPU Perc (Avg)</title>
-      <single>
-        <search>
-          <done>
-            <set token="max_cpuPerc">$result.max_cpuPerc$</set>
-          </done>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
-| stats avg(cpuPerc) AS cpuPerc</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <option name="colorBy">value</option>
-        <option name="colorMode">none</option>
-        <option name="drilldown">all</option>
-        <option name="numberPrecision">0.00</option>
-        <option name="rangeColors">["0x53a051","0xdc4e41"]</option>
-        <option name="rangeValues">[90]</option>
-        <option name="refresh.display">progressbar</option>
-        <option name="showSparkline">1</option>
-        <option name="showTrendIndicator">1</option>
-        <option name="trellis.enabled">0</option>
-        <option name="trellis.scales.shared">1</option>
-        <option name="trellis.size">medium</option>
-        <option name="trendColorInterpretation">standard</option>
-        <option name="trendDisplayMode">absolute</option>
-        <option name="unit">%</option>
-        <option name="unitPosition">after</option>
-        <option name="useColors">1</option>
-        <option name="useThousandSeparators">1</option>
-        <drilldown>
-          <set token="show_cpu_perc">true</set>
-          <unset token="show_mem_usage"></unset>
-        </drilldown>
-      </single>
-    </panel>
-    <panel>
-      <title>Memory Usage (Avg)</title>
-      <single>
-        <search>
-          <done>
-            <eval token="max_memRss">tostring($result.max_memRss$, "commas")</eval>
-          </done>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
-| stats avg(mem.rss) AS memRss</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <option name="colorBy">value</option>
-        <option name="colorMode">none</option>
-        <option name="drilldown">all</option>
-        <option name="numberPrecision">0.00</option>
-        <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
-        <option name="rangeValues">[0,30,70,100]</option>
-        <option name="refresh.display">progressbar</option>
-        <option name="showSparkline">1</option>
-        <option name="showTrendIndicator">1</option>
-        <option name="trellis.enabled">0</option>
-        <option name="trellis.scales.shared">1</option>
-        <option name="trellis.size">medium</option>
-        <option name="trendColorInterpretation">standard</option>
-        <option name="trendDisplayMode">absolute</option>
-        <option name="unit">MB</option>
-        <option name="unitPosition">after</option>
-        <option name="useColors">0</option>
-        <option name="useThousandSeparators">1</option>
-        <drilldown>
-          <set token="show_mem_usage">true</set>
-          <unset token="show_cpu_perc"></unset>
-        </drilldown>
-      </single>
-    </panel>
-  </row>
-  <row depends="$show_cpu_perc$">
-    <panel id="cpu_perc_timeline">
-      <title>CPU Perc (Avg) Breakdown by Host over Time</title>
-      <chart>
-        <search depends="$show_cpu_perc$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
-| timechart avg(cpuPerc) BY host</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <search base="annotation_search" type="annotation"></search>
-        <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisTitleY.text">Avg CPU (%)</option>
-        <option name="charting.chart">area</option>
-        <option name="charting.chart.nullValueMode">connect</option>
-        <option name="charting.drilldown">none</option>
-        <option name="charting.legend.placement">bottom</option>
-        <option name="refresh.display">progressbar</option>
-      </chart>
-    </panel>
-    <panel id="cpu_perc_breakdown">
-      <title>CPU Perc (Avg) Breakdown by Host</title>
+      <title>ERRORS</title>
+      <input type="dropdown" token="messagesplit" searchWhenChanged="true">
+        <label>Split By</label>
+        <choice value="channel">Channel</choice>
+        <choice value="message">Message</choice>
+        <default>channel</default>
+        <initialValue>channel</initialValue>
+      </input>
+      <input type="dropdown" token="logtype" searchWhenChanged="true">
+        <label>Log Type</label>
+        <choice value="api">Api</choice>
+        <choice value="w*">Worker</choice>
+        <choice value="*">All</choice>
+        <choice value="cfg*">Config events</choice>
+        <default>*</default>
+        <initialValue>*</initialValue>
+      </input>
       <table>
-        <search depends="$show_cpu_perc$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
-| stats avg(cpuPerc) AS cpuPerc BY host worker_group
-| rename host AS Host worker_group AS Group cpuPerc AS "Avg CPU %"</query>
+        <search>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ level=ERROR cid=$logtype$ | chart count sparkline by $messagesplit$ | sort -count | rename channel AS Channel message AS Message count AS Count sparkline AS Sparkline</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
         <option name="drilldown">cell</option>
+        <option name="percentagesRow">false</option>
         <option name="refresh.display">progressbar</option>
-        <format type="number" field="Avg CPU %">
-          <option name="unit">%</option>
-        </format>
-        <format type="color" field="Avg CPU %">
-          <colorPalette type="list">[#118832,#D94E17,#D41F1F]</colorPalette>
-          <scale type="threshold">90,100</scale>
-        </format>
-        <drilldown>
-          <link target="_blank">/app/criblvision/stats?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.host=$row.Host$</link>
-        </drilldown>
-      </table>
-    </panel>
-  </row>
-  <row depends="$show_mem_usage$">
-    <panel id="mem_usage_timeline">
-      <title>Memory Usage (Avg) Breakdown by Host over Time</title>
-      <chart>
-        <search depends="$show_mem_usage$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
-| timechart avg(mem.rss) BY host</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <search base="annotation_search" type="annotation"></search>
-        <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisTitleY.text">Avg Memory Usage (MB)</option>
-        <option name="charting.chart">area</option>
-        <option name="charting.chart.nullValueMode">connect</option>
-        <option name="charting.drilldown">none</option>
-        <option name="charting.legend.placement">bottom</option>
-        <option name="refresh.display">progressbar</option>
-      </chart>
-    </panel>
-    <panel id="mem_usage_breakdown">
-      <title>Memory Usage (Avg) Breakdown by Host</title>
-      <table>
-        <search depends="$show_mem_usage$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" 
-| stats avg(mem.rss) AS memRss BY host worker_group
-| rename host AS Host worker_group AS Group memRss AS "Memory Usage"</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <option name="drilldown">cell</option>
-        <option name="refresh.display">progressbar</option>
-        <format type="number" field="Memory Usage">
-          <option name="unit">MB</option>
-        </format>
-        <drilldown>
-          <link target="_blank">/app/criblvision/stats?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.host=$row.Host$</link>
-        </drilldown>
-      </table>
-    </panel>
-  </row>
-  <row>
-    <panel>
-      <title>Unhealthy Sources</title>
-      <single>
-        <search>
-          <done>
-            <set token="unhealthy_sources">$result.unhealthy_sources$</set>
-          </done>
-          <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY input group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$ health &gt; 0
-| stats count AS unhealthy_sources_count values(input) AS unhealthy_sources
-| eval unhealthy_sources = if(unhealthy_sources_count == 0, "input!=*", "input IN (\"".mvjoin(unhealthy_sources, "\", \"")."\")")</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <option name="drilldown">all</option>
-        <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
-        <option name="refresh.display">progressbar</option>
-        <drilldown>
-          <set token="show_unhealthy_sources">true</set>
-          <unset token="show_unhealthy_destinations"></unset>
-          <unset token="show_cluster_communication_errors"></unset>
-          <unset token="show_total_pq_size"></unset>
-        </drilldown>
-      </single>
-    </panel>
-    <panel>
-      <title>Unhealthy Destinations</title>
-      <single>
-        <search>
-          <done>
-            <set token="unhealthy_destinations">$result.unhealthy_destinations$</set>
-          </done>
-          <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$ health &gt; 0
-| stats count AS unhealthy_destinations_count values(output) AS unhealthy_destinations
-| eval unhealthy_destinations = if(unhealthy_destinations_count == 0, "output!=*", "output IN (\"".mvjoin(unhealthy_destinations, "\", \"")."\")")</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <option name="drilldown">all</option>
-        <option name="refresh.display">progressbar</option>
-        <drilldown>
-          <set token="show_unhealthy_destinations">true</set>
-          <unset token="show_unhealthy_sources"></unset>
-          <unset token="show_cluster_communication_errors"></unset>
-          <unset token="show_total_pq_size"></unset>
-        </drilldown>
-      </single>
-    </panel>
-    <panel>
-      <title>Cluster Communication Errors</title>
-      <single>
-        <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=clustercomm level=warn OR level=error NOT message=metric*
-| stats count AS cluster_communication_errors</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <option name="drilldown">all</option>
-        <option name="refresh.display">progressbar</option>
-        <drilldown>
-          <set token="show_cluster_communication_errors">true</set>
-          <unset token="show_unhealthy_sources"></unset>
-          <unset token="show_unhealthy_destinations"></unset>
-          <unset token="show_total_pq_size"></unset>
-        </drilldown>
-      </single>
-    </panel>
-    <panel depends="$pq_configured$">
-      <title>Historic Total PQ Size (Last 15 Minutes)</title>
-      <single>
-        <search>
-          <done>
-            <eval token="pq_configured">if($job.resultCount$ == 0, null(), "true")</eval>
-            <eval token="pq_not_configured">if($job.resultCount$ == 0, "true", null())</eval>
-          </done>
-          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS total_pq_size WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$
-| stats sum(total_pq_size) AS total_pq_size</query>
-          <earliest>-15m</earliest>
-          <latest>now</latest>
-          <sampleRatio>1</sampleRatio>
-        </search>
-        <option name="colorBy">value</option>
-        <option name="colorMode">none</option>
-        <option name="drilldown">all</option>
-        <option name="numberPrecision">0</option>
-        <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
-        <option name="rangeValues">[0,30,70,100]</option>
-        <option name="refresh.display">progressbar</option>
-        <option name="showSparkline">1</option>
-        <option name="showTrendIndicator">1</option>
-        <option name="trellis.enabled">0</option>
-        <option name="trellis.scales.shared">1</option>
-        <option name="trellis.size">medium</option>
-        <option name="trendColorInterpretation">standard</option>
-        <option name="trendDisplayMode">absolute</option>
-        <option name="unit">B</option>
-        <option name="unitPosition">after</option>
-        <option name="useColors">0</option>
-        <option name="useThousandSeparators">1</option>
-        <drilldown>
-          <set token="show_total_pq_size">true</set>
-          <unset token="show_unhealthy_sources"></unset>
-          <unset token="show_unhealthy_destinations"></unset>
-          <unset token="show_cluster_communication_errors"></unset>
-        </drilldown>
-      </single>
-    </panel>
-    <panel depends="$pq_not_configured$">
-      <title>Historic Total PQ Size (Last 15 Minutes)</title>
-      <single>
-        <search>
-          <query>| makeresults | eval message = "Not Configured"</query>
-          <earliest>-1s</earliest>
-          <latest>now</latest>
-        </search>
-        <option name="refresh.display">progressbar</option>
-      </single>
-    </panel>
-  </row>
-  <row depends="$show_unhealthy_sources$">
-    <panel>
-      <html>
-        <div style="font-family: Arial; font-size: 11pt; list-style-type: square; text-align: center;">
-          <p>
-            <b>Note:</b> Hover over individual Sources in the legend to highlight them on the graph. The status values represent the health of a Source as documented in the <a href="https://docs.cribl.io/stream/internal-metrics/#health">System Health Metrics</a> section of the Cribl Docs:</p>
-            <p>0 = Healthy</p>
-            <p>1 = Warning</p>
-            <p>2 = Trouble</p>
-        </div>
-      </html>
-    </panel>
-  </row>
-  <row depends="$show_unhealthy_sources$">
-    <panel>
-      <title>Unhealthy Sources over Time</title>
-      <chart>
-        <search depends="$show_unhealthy_sources$">
-          <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $unhealthy_sources$ span=auto BY input group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$
-| timechart max(health) BY input</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <search base="annotation_search" type="annotation"></search>
-        <option name="charting.axisLabelsY.majorUnit">1</option>
-        <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisTitleY.text">Status</option>
-        <option name="charting.axisY.maximumNumber">2</option>
-        <option name="charting.axisY.minimumNumber">0</option>
-        <option name="charting.chart">area</option>
-        <option name="charting.chart.nullValueMode">zero</option>
-        <option name="charting.chart.overlayFields">warning,troubled</option>
-        <option name="charting.legend.placement">bottom</option>
-        <option name="refresh.display">progressbar</option>
-      </chart>
-    </panel>
-    <panel>
-      <title>Unhealthy Sources Breakdown</title>
-      <table>
-        <search depends="$show_unhealthy_sources$">
-          <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $unhealthy_sources$ span=auto BY input host group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$
-| stats sparkline(max(health)) AS sparkline BY input host group
-| rex field=input "(?&lt;technology&gt;[^:]+):(?&lt;input&gt;.*)" 
-| table technology input host group sparkline
-| rename technology AS Technology input AS Source host AS Host group AS Group sparkline AS "Health Sparkline"</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <option name="refresh.display">progressbar</option>
-        <drilldown>
-          <link target="_blank">/app/criblvision/sources_and_destinations_overview?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.host=$row.Host$&amp;form.worker_group=$row.Group$&amp;form.selected=$row.Source$&amp;form.full_selected=$row.Technology$:$row.Source$&amp;form.type=in&amp;type_printable=In</link>
-        </drilldown>
-      </table>
-    </panel>
-  </row>
-  <row depends="$show_unhealthy_destinations$">
-    <panel>
-      <html>
-        <div style="font-family: Arial; font-size: 11pt; list-style-type: square; text-align: center;">
-          <p>
-            <b>Note:</b> Hover over individual Destinations in the legend to highlight them on the graph. The status values represent the health of a Destination as documented in the <a href="https://docs.cribl.io/stream/internal-metrics/#health">System Health Metrics</a> section of the Cribl Docs:</p>
-            <p>0 = Healthy</p>
-            <p>1 = Warning</p>
-            <p>2 = Trouble</p>
-        </div>
-      </html>
-    </panel>
-  </row>
-  <row depends="$show_unhealthy_destinations$">
-    <panel>
-      <title>Unhealthy Destinations over Time</title>
-      <chart>
-        <search depends="$show_unhealthy_destinations$">
-          <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $unhealthy_destinations$ span=auto BY output group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$
-| timechart max(health) BY output</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <search base="annotation_search" type="annotation"></search>
-        <option name="charting.axisLabelsY.majorUnit">1</option>
-        <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisTitleY.text">Status</option>
-        <option name="charting.axisY.maximumNumber">2</option>
-        <option name="charting.axisY.minimumNumber">0</option>
-        <option name="charting.chart">area</option>
-        <option name="charting.chart.nullValueMode">zero</option>
-        <option name="charting.chart.overlayFields">warning,troubled</option>
-        <option name="charting.legend.placement">bottom</option>
-        <option name="refresh.display">progressbar</option>
-      </chart>
-    </panel>
-    <panel>
-      <title>Unhealthy Destinations Breakdown</title>
-      <table>
-        <search depends="$show_unhealthy_destinations$">
-          <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ $unhealthy_destinations$ span=auto BY output host group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$
-| stats sparkline(max(health)) AS sparkline BY output host group
-| rex field=output "(?&lt;technology&gt;[^:]+):(?&lt;output&gt;.*)" 
-| table technology output host group sparkline
-| rename technology AS Technology output AS Destination host AS Host group AS Group sparkline AS "Health Sparkline"</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <option name="refresh.display">progressbar</option>
-        <drilldown>
-          <link target="_blank">/app/criblvision/sources_and_destinations_overview?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.host=$row.Host$&amp;form.worker_group=$row.Group$&amp;form.selected=$row.Destination$&amp;form.full_selected=$row.Technology$:$row.Destination$&amp;form.type=out&amp;type_printable=Out</link>
-        </drilldown>
-      </table>
-    </panel>
-  </row>
-  <row depends="$show_cluster_communication_errors$">
-    <panel>
-      <title>Cluster Communication Errors Breakdown</title>
-      <table>
-        <search depends="$show_cluster_communication_errors$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=clustercomm level=warn OR level=error NOT message=metric*
-| stats count BY host worker_group
-| rename host AS Host worker_group AS Group count AS "Cluster Communication Errors"</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <option name="drilldown">cell</option>
-        <option name="refresh.display">progressbar</option>
-        <drilldown>
-          <link target="_blank">search?q=%60set_cribl_internal_log_index%60%20host%3D$row.Host$%20worker_group%3D$row.Group$%20channel%3Dclustercomm%20level%3Dwarn%20OR%20level%3Derror%20NOT%20message%3Dmetric*&amp;earliest=$time.earliest$&amp;latest=$time.latest$</link>
-        </drilldown>
-      </table>
-    </panel>
-  </row>
-  <row depends="$show_total_pq_size$">
-    <panel>
-      <html>
-        <div style="font-family: Arial; font-size: 11pt; list-style-type: square; text-align: center;">
-          <p>
-            <b>Note:</b> The PQ panels are locked to showing data from the last 15 minutes to give an up-to-date view of the PQ size.</p>
-        </div>
-      </html>
-    </panel>
-  </row>
-  <row depends="$show_total_pq_size$">
-    <panel id="total_pq_size_timeline">
-      <title>PQ Size by Host (Last 15 Minutes)</title>
-      <chart>
-        <search depends="$show_total_pq_size$">
-          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ span=auto BY host prestats=true
-| timechart sum(`set_cribl_metrics_prefix("pq.queue_size")`) BY host</query>
-          <earliest>-15m</earliest>
-          <latest>now</latest>
-        </search>
-        <search base="annotation_search" type="annotation"></search>
-        <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisTitleY.text">PQ Size (B)</option>
-        <option name="charting.chart">line</option>
-        <option name="charting.chart.nullValueMode">zero</option>
-        <option name="charting.chart.showDataLabels">none</option>
-        <option name="charting.drilldown">none</option>
-        <option name="charting.legend.placement">bottom</option>
-        <option name="refresh.display">progressbar</option>
-      </chart>
-    </panel>
-    <panel id="total_pq_size_breakdown">
-      <title>Historic Total PQ Size by Host (Last 15 Minutes)</title>
-      <table>
-        <search depends="$show_total_pq_size$">
-          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS total_pq_size WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY host group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$
-| rename host AS Host group AS Group total_pq_size AS "Total PQ Size"</query>
-          <earliest>-15m</earliest>
-          <latest>now</latest>
-        </search>
-        <option name="drilldown">cell</option>
-        <option name="refresh.display">progressbar</option>
-        <format type="number" field="Total PQ Size">
+        <format type="number" field="Count">
           <option name="precision">0</option>
-          <option name="unit">B</option>
         </format>
         <drilldown>
-          <link target="_blank">/app/criblvision/persistent_queue_analytics?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.host=$row.Host$</link>
+          <set token="level">ERROR</set>
+          <set token="name">$messagesplit$</set>
+          <set token="value">$click.value$</set>
+          <set token="cid">$logtype$</set>
         </drilldown>
       </table>
     </panel>
-  </row>
-  <row>
     <panel>
-      <title>Worker Process Restarts</title>
-      <single>
-        <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=cribl* message="restarting worker process"
-| stats count AS worker_process_restarts</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <option name="colorBy">value</option>
-        <option name="colorMode">none</option>
-        <option name="drilldown">all</option>
-        <option name="numberPrecision">0</option>
-        <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
-        <option name="rangeValues">[0,30,70,100]</option>
-        <option name="refresh.display">progressbar</option>
-        <option name="showSparkline">1</option>
-        <option name="showTrendIndicator">1</option>
-        <option name="trellis.enabled">0</option>
-        <option name="trellis.scales.shared">1</option>
-        <option name="trellis.size">medium</option>
-        <option name="trendColorInterpretation">standard</option>
-        <option name="trendDisplayMode">absolute</option>
-        <option name="unitPosition">after</option>
-        <option name="useColors">0</option>
-        <option name="useThousandSeparators">1</option>
-        <drilldown>
-          <set token="show_worker_process_restarts">true</set>
-          <unset token="show_backpressured_destinations"></unset>
-          <unset token="show_blocked_destinations"></unset>
-          <unset token="show_pq_engaged"></unset>
-        </drilldown>
-      </single>
-    </panel>
-    <panel>
-      <title>Destinations with Backpressure</title>
-      <single>
-        <search>
-          <done>
-            <eval token="max_back_pressured">tostring($result.max_back_pressured$, "commas")</eval>
-          </done>
-          <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) AS back_pressured WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$ back_pressured &gt; 0
-| stats count AS back_pressured_destinations</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <option name="drilldown">all</option>
-        <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
-        <option name="refresh.display">progressbar</option>
-        <drilldown>
-          <set token="show_backpressured_destinations">true</set>
-          <unset token="show_worker_process_restarts"></unset>
-          <unset token="show_blocked_destinations"></unset>
-          <unset token="show_pq_engaged"></unset>
-        </drilldown>
-      </single>
-    </panel>
-    <panel>
-      <title>Blocked Destinations</title>
-      <single>
-        <search>
-          <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) AS blocked WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$ blocked &gt; 0
-| stats count AS blocked_destinations</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <option name="drilldown">all</option>
-        <option name="refresh.display">progressbar</option>
-        <drilldown>
-          <set token="show_blocked_destinations">true</set>
-          <unset token="show_worker_process_restarts"></unset>
-          <unset token="show_backpressured_destinations"></unset>
-          <unset token="show_pq_engaged"></unset>
-        </drilldown>
-      </single>
-    </panel>
-    <panel>
-      <title>Destinations with PQ Engaged (Last 15 Minutes)</title>
-      <single>
-        <search>
-          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) as pq_engaged WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output
-| search pq_engaged &gt; 0
-| stats count AS pq_engaged</query>
-          <earliest>-15m</earliest>
-          <latest>now</latest>
-          <sampleRatio>1</sampleRatio>
-        </search>
-        <option name="colorBy">value</option>
-        <option name="colorMode">none</option>
-        <option name="drilldown">all</option>
-        <option name="numberPrecision">0</option>
-        <option name="rangeColors">["0x53a051", "0x0877a6", "0xf8be34", "0xf1813f", "0xdc4e41"]</option>
-        <option name="rangeValues">[0,30,70,100]</option>
-        <option name="refresh.display">progressbar</option>
-        <option name="showSparkline">1</option>
-        <option name="showTrendIndicator">1</option>
-        <option name="trellis.enabled">0</option>
-        <option name="trellis.scales.shared">1</option>
-        <option name="trellis.size">medium</option>
-        <option name="trendColorInterpretation">standard</option>
-        <option name="trendDisplayMode">absolute</option>
-        <option name="unitPosition">after</option>
-        <option name="useColors">0</option>
-        <option name="useThousandSeparators">1</option>
-        <drilldown>
-          <set token="show_pq_engaged">true</set>
-          <unset token="show_worker_process_restarts"></unset>
-          <unset token="show_backpressured_destinations"></unset>
-          <unset token="show_blocked_destinations"></unset>
-        </drilldown>
-      </single>
-    </panel>
-  </row>
-  <row depends="$show_worker_process_restarts$">
-    <panel id="worker_process_reset_timeline">
-      <title>Worker Process Restarts by Host over Time</title>
-      <chart>
-        <search depends="$show_worker_process_restarts$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=cribl* message="restarting worker process" 
-| timechart count BY host</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <search base="annotation_search" type="annotation"></search>
-        <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisTitleY.text">Worker Process Restarts</option>
-        <option name="charting.chart">area</option>
-        <option name="charting.chart.nullValueMode">zero</option>
-        <option name="charting.chart.stackMode">stacked</option>
-        <option name="charting.drilldown">none</option>
-        <option name="charting.legend.placement">bottom</option>
-        <option name="refresh.display">progressbar</option>
-      </chart>
-    </panel>
-    <panel id="worker_process_reset_breakdown">
-      <title>Worker Process Restarts by Host</title>
+      <title>WARNS</title>
+      <input type="dropdown" token="messagesplit1" searchWhenChanged="true">
+        <label>Split By</label>
+        <choice value="channel">Channel</choice>
+        <choice value="message">Message</choice>
+        <default>channel</default>
+        <initialValue>channel</initialValue>
+      </input>
+      <input type="dropdown" token="logtype1" searchWhenChanged="true">
+        <label>Log Type</label>
+        <choice value="api">Api</choice>
+        <choice value="w*">Worker</choice>
+        <choice value="*">All</choice>
+        <choice value="cfg*">Config events</choice>
+        <default>*</default>
+        <initialValue>*</initialValue>
+      </input>
       <table>
-        <search depends="$show_worker_process_restarts$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=cribl* message="restarting worker process" 
-| stats count sparkline BY host
-| rename host AS Host count AS "Worker Restarts" sparkline AS Sparkline</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <option name="drilldown">none</option>
-        <option name="refresh.display">progressbar</option>
-      </table>
-    </panel>
-  </row>
-  <row depends="$show_backpressured_destinations$">
-    <panel id="backpressured_destinations_timeline">
-      <title>Destinations with Backpressure over Time</title>
-      <chart>
-        <search depends="$show_backpressured_destinations$">
-          <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) AS back_pressured WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group span=auto fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$ back_pressured!=0
-| timechart max(back_pressured) BY output</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <search base="annotation_search" type="annotation"></search>
-        <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisTitleY.text">Back Pressure</option>
-        <option name="charting.axisY.minimumNumber">0</option>
-        <option name="charting.chart">area</option>
-        <option name="charting.chart.nullValueMode">zero</option>
-        <option name="charting.chart.stackMode">stacked</option>
-        <option name="charting.drilldown">none</option>
-        <option name="charting.legend.placement">bottom</option>
-        <option name="refresh.display">progressbar</option>
-      </chart>
-    </panel>
-    <panel id="backpressured_destinations_breakdown">
-      <title>Destinations with Backpressure Breakdown</title>
-      <table>
-        <search depends="$show_backpressured_destinations$">
-          <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) AS back_pressured WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output host group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$ back_pressured &gt; 0
-| rex field=output "(?&lt;technology&gt;[^:]+):(?&lt;output&gt;.*)" 
-| table technology output host group
-| rename technology AS Technology output AS Destination host AS Host group AS Group</query>
+        <search>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ level=WARN cid=$logtype1$ | chart count sparkline by $messagesplit1$ | sort -count | rename channel AS Channel message AS Message count AS Count sparkline AS Sparkline</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
         <option name="drilldown">cell</option>
         <option name="refresh.display">progressbar</option>
+        <format type="number" field="Count">
+          <option name="precision">0</option>
+        </format>
         <drilldown>
-          <link target="_blank">/app/criblvision/sources_and_destinations_overview?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.worker_group=$row.Group$&amp;form.host=$row.Host$&amp;form.selected=$row.Destination$&amp;form.full_selected=$row.Technology$:$row.Destination$&amp;form.type=out&amp;type_printable=Out</link>
+          <set token="level">WARN</set>
+          <set token="name">$messagesplit$</set>
+          <set token="value">$click.value$</set>
+          <set token="cid">$logtype1$</set>
         </drilldown>
       </table>
     </panel>
-  </row>
-  <row depends="$show_blocked_destinations$">
-    <panel id="blocked_destinations_timeline">
-      <title>Blocked Destinations over Time</title>
-      <chart>
-        <search depends="$show_blocked_destinations$">
-          <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) AS blocked WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group span=auto fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$ blocked!=0
-| timechart max(blocked) BY output</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-        </search>
-        <search base="annotation_search" type="annotation"></search>
-        <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisTitleY.text">Back Pressure</option>
-        <option name="charting.axisY.abbreviation">none</option>
-        <option name="charting.axisY.minimumNumber">0</option>
-        <option name="charting.chart">area</option>
-        <option name="charting.chart.nullValueMode">zero</option>
-        <option name="charting.chart.stackMode">stacked</option>
-        <option name="charting.drilldown">none</option>
-        <option name="charting.legend.placement">bottom</option>
-        <option name="refresh.display">progressbar</option>
-      </chart>
-    </panel>
-    <panel id="blocked_destinations_breakdown">
-      <title>Blocked Destinations Breakdown</title>
+    <panel>
+      <title>INFO</title>
+      <input type="dropdown" token="messagesplit2" searchWhenChanged="true">
+        <label>Split By</label>
+        <choice value="channel">Channel</choice>
+        <choice value="message">Message</choice>
+        <default>channel</default>
+        <initialValue>channel</initialValue>
+      </input>
+      <input type="dropdown" token="logtype2" searchWhenChanged="true">
+        <label>Log Type</label>
+        <choice value="api">Api</choice>
+        <choice value="w*">Worker</choice>
+        <choice value="*">All</choice>
+        <choice value="cfg*">Config events</choice>
+        <default>*</default>
+        <initialValue>*</initialValue>
+      </input>
       <table>
-        <search depends="$show_blocked_destinations$">
-          <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) AS blocked WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output host group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$ blocked &gt; 0
-| rex field=output "(?&lt;technology&gt;[^:]+):(?&lt;output&gt;.*)" 
-| table technology output host group
-| rename technology AS Technology output AS Destination host AS Host group AS Group</query>
+        <search>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ level=INFO cid=$logtype2$ | chart count sparkline by $messagesplit2$ | sort -count | rename channel AS Channel message AS Message count AS Count sparkline AS Sparkline</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
         <option name="drilldown">cell</option>
         <option name="refresh.display">progressbar</option>
+        <format type="number" field="Count">
+          <option name="precision">0</option>
+        </format>
         <drilldown>
-          <link target="_blank">/app/criblvision/sources_and_destinations_overview?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.worker_group=$row.Group$&amp;form.host=$row.Host$&amp;form.selected=$row.Destination$&amp;form.full_selected=$row.Technology$:$row.Destination$&amp;form.type=out&amp;type_printable=Out</link>
+          <set token="level">INFO</set>
+          <set token="name">$messagesplit2$</set>
+          <set token="value">$click.value$</set>
+          <set token="cid">$logtype2$</set>
+        </drilldown>
+      </table>
+    </panel>
+    <panel depends="$show_debug$">
+      <title>DEBUG</title>
+      <input type="dropdown" token="messagesplit3" searchWhenChanged="true">
+        <label>Split By</label>
+        <choice value="channel">Channel</choice>
+        <choice value="message">Message</choice>
+        <default>channel</default>
+        <initialValue>channel</initialValue>
+      </input>
+      <input type="dropdown" token="logtype3" searchWhenChanged="true">
+        <label>Log Type</label>
+        <choice value="api">Api</choice>
+        <choice value="w*">Worker</choice>
+        <choice value="*">All</choice>
+        <choice value="cfg*">Config events</choice>
+        <default>*</default>
+        <initialValue>*</initialValue>
+      </input>
+      <table>
+        <search>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ level=DEBUG cid=$logtype3$ | chart count sparkline by $messagesplit3$ | sort -count | rename channel AS Channel message AS Message count AS Count sparkline AS Sparkline</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="drilldown">cell</option>
+        <option name="percentagesRow">false</option>
+        <option name="refresh.display">progressbar</option>
+        <format type="number" field="Count">
+          <option name="precision">0</option>
+        </format>
+        <drilldown>
+          <set token="level">DEBUG</set>
+          <set token="name">$messagesplit3$</set>
+          <set token="value">$click.value$</set>
+          <set token="cid">$logtype3$</set>
         </drilldown>
       </table>
     </panel>
   </row>
-  <row depends="$show_pq_engaged$">
-    <panel id="pq_engaged_timeline">
-      <title>Destinations with PQ Engaged over Time (Last 15 Minutes)</title>
-      <chart>
-        <search depends="$show_pq_engaged$">
-          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_engaged WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output host group span=auto fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$
-| eval pq_engaged = min(pq_engaged, 1)
-| timechart max(pq_engaged) BY output</query>
-          <earliest>-15m</earliest>
-          <latest>now</latest>
+  <row depends="$name$">
+    <panel>
+      <event>
+        <search>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ $name$=$value|s$ cid=$cid$ level=$level$</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
-        <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisTitleY.text">PQs Engaged</option>
-        <option name="charting.chart">area</option>
-        <option name="charting.chart.nullValueMode">zero</option>
-        <option name="charting.chart.stackMode">stacked100</option>
-        <option name="charting.drilldown">none</option>
-        <option name="charting.legend.placement">bottom</option>
-        <option name="refresh.display">progressbar</option>
-      </chart>
-    </panel>
-    <panel id="pq_engaged_breakdown">
-      <title>Destinations with PQ Engaged Breakdown (Last 15 Minutes)</title>
-      <table>
-        <search depends="$show_pq_engaged$">
-          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_engaged WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output host group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$
-| rex field=output "(?&lt;technology&gt;[^:]+):(?&lt;output&gt;.*)" 
-| table technology output host group
-| rename technology AS Technology output AS Destination host AS Host group AS Group</query>
-          <earliest>-15m</earliest>
-          <latest>now</latest>
-        </search>
-        <option name="drilldown">cell</option>
+        <option name="list.drilldown">full</option>
         <option name="refresh.display">progressbar</option>
         <drilldown>
-          <link target="_blank">/app/criblvision/sources_and_destinations_overview?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.worker_group=$row.Group$&amp;form.host=$row.Host$&amp;form.selected=$row.Destination$&amp;form.full_selected=$row.Technology$:$row.Destination$&amp;form.type=out&amp;type_printable=Out</link>
+          <link target="_blank">search?q=%60set_cribl_internal_log_index%60%20source%3D*.log%20$name$%3D$value|s$%20level%3D$level$&amp;earliest=$time.earliest$&amp;latest=$time.latest$</link>
         </drilldown>
-      </table>
+      </event>
     </panel>
   </row>
 </form>

--- a/criblvision/default/data/ui/views/job_inspector.xml
+++ b/criblvision/default/data/ui/views/job_inspector.xml
@@ -8,11 +8,33 @@
         <latest>now</latest>
       </default>
     </input>
-    <input type="dropdown" token="host" searchWhenChanged="true">&gt;<label>Leader Host</label>
+    <input type="dropdown" token="environment" searchWhenChanged="true">
+      <label>Environment</label>
+      <choice value="*">All Environments</choice>
+      <fieldForLabel>environment</fieldForLabel>
+      <fieldForValue>hosts</fieldForValue>
+      <search>
+        <query>| `dashboard_cribl_environment_filter`</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition label="All Environments">
+          <set token="environment_filter"></set>
+        </condition>
+        <condition>
+          <set token="environment_filter">host IN ($environment$)</set>
+        </condition>
+      </change>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
+    <input type="dropdown" token="host" searchWhenChanged="true">
+      <label>Leader Host</label>
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| `dashboard_host_filter("instance_type=leader")`</query>
+        <query>| `dashboard_host_filter($environment_filter|s$ instance_type=leader)`</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>
@@ -29,7 +51,7 @@
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>worker_group</fieldForValue>
       <search>
-        <query>| `dashboard_worker_group_filter`</query>
+        <query>| `dashboard_worker_group_filter($environment_filter|s$)`</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
@@ -39,7 +61,7 @@
       <fieldForLabel>JobName</fieldForLabel>
       <fieldForValue>JobName</fieldForValue>
       <search>
-        <query>| tstats values(source) AS source WHERE `set_cribl_internal_log_index` source IN ("*state/jobs/*") $host$ 
+        <query>| tstats values(source) AS source WHERE `set_cribl_internal_log_index` source IN ("*state/jobs/*") $environment_filter$ $host$ 
 | mvexpand source 
 | rex field=source "state\/jobs\/(?&lt;WorkerGroup&gt;.*?)\/(?&lt;JobId&gt;.*?)\/"
 | rex field=JobId "^.*\d+\.\d+\.(scheduled|adhoc|system)\.(?&lt;JobName&gt;.*)"

--- a/criblvision/default/data/ui/views/leader_performance_introspection.xml
+++ b/criblvision/default/data/ui/views/leader_performance_introspection.xml
@@ -12,12 +12,33 @@
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="environment" searchWhenChanged="true">
+      <label>Environment</label>
+      <choice value="*">All Environments</choice>
+      <fieldForLabel>environment</fieldForLabel>
+      <fieldForValue>hosts</fieldForValue>
+      <search>
+        <query>| `dashboard_cribl_environment_filter`</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition label="All Environments">
+          <set token="environment_filter"></set>
+        </condition>
+        <condition>
+          <set token="environment_filter">host IN ($environment$)</set>
+        </condition>
+      </change>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
     <input type="dropdown" token="host" searchWhenChanged="false">
       <label>Leader Host</label>
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| `dashboard_host_filter("instance_type=leader")`</query>
+        <query>| `dashboard_host_filter($environment_filter|s$ instance_type=leader)`</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>
@@ -57,7 +78,7 @@
       <title>Leader CPU Usage</title>
       <single>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ instance_type=leader channel=ProcessMetrics cid IN ("api")
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ instance_type=leader channel=ProcessMetrics cid IN ("api")
 | stats avg(cpuPerc) as cpuPerc</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -88,7 +109,7 @@
       <title>Leader Memory Usage</title>
       <single>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ instance_type=leader channel=ProcessMetrics cid IN ("api")
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ instance_type=leader channel=ProcessMetrics cid IN ("api")
 | stats avg(mem.rss) as memRss</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -121,7 +142,7 @@
       <title>Leader CPU by API Process</title>
       <chart>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ instance_type=leader channel=ProcessMetrics cid IN ("api", "service:*")
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ instance_type=leader channel=ProcessMetrics cid IN ("api", "service:*")
 | timechart limit=1000 useother=f max(cpuPerc) AS max_cpuPerc by cid</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -180,7 +201,7 @@
       </input>
       <chart>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ instance_type=leader source IN ("*/access.log", "*/access1.log", "*/access2.log", "*/access3.log", "*/access4.log") response_time=*
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ instance_type=leader source IN ("*/access.log", "*/access1.log", "*/access2.log", "*/access3.log", "*/access4.log") response_time=*
 | timechart limit=1000 useother=f sum(response_time) AS sum_response_time $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>

--- a/criblvision/default/data/ui/views/persistent_queue_analytics.xml
+++ b/criblvision/default/data/ui/views/persistent_queue_analytics.xml
@@ -12,6 +12,27 @@
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="environment" searchWhenChanged="true">
+      <label>Environment</label>
+      <choice value="*">All Environments</choice>
+      <fieldForLabel>environment</fieldForLabel>
+      <fieldForValue>hosts</fieldForValue>
+      <search>
+        <query>| `dashboard_cribl_environment_filter`</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition label="All Environments">
+          <set token="environment_filter"></set>
+        </condition>
+        <condition>
+          <set token="environment_filter">host IN ($environment$)</set>
+        </condition>
+      </change>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
     <input type="dropdown" token="worker_group" searchWhenChanged="true">
       <label>Worker Group / Single</label>
       <choice value="all_instances">All Instances</choice>
@@ -20,7 +41,7 @@
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>worker_group</fieldForValue>
       <search>
-        <query>| `dashboard_worker_group_filter`</query>
+        <query>| `dashboard_worker_group_filter($environment_filter|s$)`</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
@@ -49,12 +70,12 @@
       <default>all_instances</default>
       <initialValue>all_instances</initialValue>
     </input>
-    <input type="dropdown" token="host">
+    <input type="dropdown" token="host" searchWhenChanged="true">
       <label>Host</label>
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| `dashboard_host_filter($worker_group_event_filter|s$)`</query>
+        <query>| `dashboard_host_filter($environment_filter|s$ $worker_group_event_filter|s$)`</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>
@@ -94,7 +115,7 @@
       <title>Count of Destinations with PQ Engaged</title>
       <single>
         <search>
-          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) as pq_engaged WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) as pq_engaged WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$ pq_engaged &gt; 0
 | stats count</query>
           <earliest>$time.earliest$</earliest>
@@ -124,7 +145,7 @@
       <title>Latest PQ Size</title>
       <single>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) as total_pq_size WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) as total_pq_size WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | stats sum(total_pq_size) AS total_pq_size</query>
           <earliest>$time.earliest$</earliest>
@@ -155,7 +176,7 @@
       <title>Destinations with PQ Engaged</title>
       <table>
         <search>
-          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_engaged WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_engaged WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY output group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$ pq_engaged &gt; 0 
 | dedup output
 | fields - pq_engaged
@@ -179,8 +200,9 @@
     <panel>
       <title>PQ Size by Destination</title>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_size WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ span=auto BY output group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_size WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ span=auto BY output group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | timechart sum(pq_size) useother=false BY output WHERE max in top100
 | fields - _span*</query>
@@ -188,7 +210,6 @@
           <latest>$time.latest$</latest>
           <sampleRatio>1</sampleRatio>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisLabelsX.majorLabelStyle.overflowMode">ellipsisNone</option>
         <option name="charting.axisLabelsX.majorLabelStyle.rotation">0</option>
         <option name="charting.axisTitleX.text">Time</option>
@@ -238,7 +259,7 @@
       </input>
       <event>
         <search>
-          <query>`set_cribl_internal_log_index` $host$ $worker_group_event_filter$ channel="IPersistentQueue"</query>
+          <query>`set_cribl_internal_log_index` $environment_filter$ $host$ $worker_group_event_filter$ channel="IPersistentQueue"</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
           <sampleRatio>1</sampleRatio>

--- a/criblvision/default/data/ui/views/sizingcalculator.xml
+++ b/criblvision/default/data/ui/views/sizingcalculator.xml
@@ -8,6 +8,27 @@
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="environment" searchWhenChanged="true">
+      <label>Environment</label>
+      <choice value="*">All Environments</choice>
+      <fieldForLabel>environment</fieldForLabel>
+      <fieldForValue>hosts</fieldForValue>
+      <search>
+        <query>| `dashboard_cribl_environment_filter`</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition label="All Environments">
+          <set token="environment_filter"></set>
+        </condition>
+        <condition>
+          <set token="environment_filter">host IN ($environment$)</set>
+        </condition>
+      </change>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
     <input type="dropdown" token="worker_group" searchWhenChanged="true">
       <label>Worker Group / Single</label>
       <choice value="all_instances">All Instances</choice>
@@ -16,7 +37,7 @@
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>worker_group</fieldForValue>
       <search>
-        <query>| `dashboard_worker_group_filter`</query>
+        <query>| `dashboard_worker_group_filter($environment_filter|s$)`</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
@@ -42,7 +63,7 @@
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| `dashboard_host_filter($worker_group_event_filter|s$)`</query>
+        <query>| `dashboard_host_filter($environment_filter|s$ $worker_group_event_filter|s$)`</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>
@@ -131,7 +152,7 @@
           <done>
             <set token="workerProcessCount">$result.WorkerProcessCount$</set>
           </done>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel="server" message="_raw stats"
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel="server" message="_raw stats"
 | stats dc(cid) AS WorkerProcessCount BY host
 | stats sum(WorkerProcessCount) AS WorkerProcessCount</query>
           <earliest>$time.earliest$</earliest>
@@ -180,7 +201,7 @@
       <title>Total Throughput (inBytes + outBytes) in GB</title>
       <chart>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel="server" message="_raw stats"
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel="server" message="_raw stats"
 | bin span=1d _time
 | stats sum(inBytes) AS inBytes sum(outBytes) AS outBytes by _time
 | eval totalGB=round((('inBytes' + 'outBytes') / 1024 / 1024 / 1024), 0)
@@ -200,7 +221,7 @@
       <title>Estimated Worker Processes Required</title>
       <chart>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel="server" message="_raw stats"
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel="server" message="_raw stats"
 | bin span=1d _time
 | stats sum(inBytes) AS inBytes sum(outBytes) AS outBytes by _time
 | eval inGB=round(('inBytes' / 1024 / 1024 / 1024), 0)
@@ -224,7 +245,7 @@
       <title>Estimated Worker Processes Required, Based on DAILY Throughput over the Selected Time Range</title>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel="server" message="_raw stats"
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel="server" message="_raw stats"
 | bin span=1d _time
 | stats sum(inBytes) AS inBytes sum(outBytes) AS outBytes by _time
 | eval date = strftime(_time, "%Y-%m-%d")
@@ -262,7 +283,7 @@
       <title>Percentage, over the Selected Time Range, that a Worker Process Exceeded 90%  cpuPerc Usage</title>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel="server" message="_raw stats"
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel="server" message="_raw stats"
 | bin span=1m _time
 | stats max(cpuPerc) AS cpuPerc BY _time cid
 | eval percentage=if(cpuPerc &gt;= 90, 1, 0)
@@ -289,7 +310,7 @@
       <title>Percentage, over the Selected Time Range, that a Worker Process exceeded 90% eluPerc Usage</title>
       <table>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel="server" message="_raw stats" 
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel="server" message="_raw stats" 
 | bin span=1m _time 
 | stats max(eluPerc) AS eluPerc BY _time cid 
 | eval percentage = if(eluPerc &gt;= 90, 1, 0) 

--- a/criblvision/default/data/ui/views/sources_and_destinations_overview.xml
+++ b/criblvision/default/data/ui/views/sources_and_destinations_overview.xml
@@ -8,7 +8,7 @@
     <latest>$time.latest$</latest>
   </search>
   <search id="messages_base_search">
-    <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ channel="$type$put:$selected$" $worker_group_event_filter$ level=* 
+    <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ channel="$type$put:$selected$" $worker_group_event_filter$ level=* 
 | stats count sparkline(count) AS sparkline BY channel message level
 | sort - count
 | rename channel AS Channel message AS Messages count AS Count sparkline AS Sparkline</query>
@@ -23,6 +23,27 @@
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="environment" searchWhenChanged="true">
+      <label>Environment</label>
+      <choice value="*">All Environments</choice>
+      <fieldForLabel>environment</fieldForLabel>
+      <fieldForValue>hosts</fieldForValue>
+      <search>
+        <query>| `dashboard_cribl_environment_filter`</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition label="All Environments">
+          <set token="environment_filter"></set>
+        </condition>
+        <condition>
+          <set token="environment_filter">host IN ($environment$)</set>
+        </condition>
+      </change>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
 <input type="dropdown" token="worker_group" searchWhenChanged="true">
       <label>Worker Group / Single</label>
       <choice value="all_instances">All Instances</choice>
@@ -31,7 +52,7 @@
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>worker_group</fieldForValue>
       <search>
-        <query>| `dashboard_worker_group_filter`</query>
+        <query>| `dashboard_worker_group_filter($environment_filter|s$)`</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
@@ -65,7 +86,7 @@
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| `dashboard_host_filter($worker_group_event_filter|s$)`</query>
+        <query>| `dashboard_host_filter($environment_filter|s$ $worker_group_event_filter|s$)`</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>
@@ -95,7 +116,7 @@
       <fieldForLabel>$type$put</fieldForLabel>
       <fieldForValue>selected</fieldForValue>
       <search>
-        <query>| mstats sum(`set_cribl_metrics_prefix(health.$type$puts)`) WHERE `set_cribl_metrics_index` $host$ $worker_group_metric_pre_filter$ BY $type$put group fillnull_value=`set_unknown_worker_group_value`
+        <query>| mstats sum(`set_cribl_metrics_prefix(health.$type$puts)`) WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $worker_group_metric_pre_filter$ BY $type$put group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$ 
 | rex field=$type$put "[^:]+:(?&lt;selected&gt;.*)" 
 | stats count BY $type$put selected</query>
@@ -136,7 +157,7 @@
       <single>
         <title>Total Bytes $type_printable$</title>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(total.$type$_bytes)`) AS $type$_bytes WHERE `set_cribl_metrics_index` $host$ $type$put="$full_selected$" $worker_group_metric_pre_filter$ BY group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats sum(`set_cribl_metrics_prefix(total.$type$_bytes)`) AS $type$_bytes WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $type$put="$full_selected$" $worker_group_metric_pre_filter$ BY group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | stats sum($type$_bytes) AS $type$_bytes</query>
           <earliest>$time.earliest$</earliest>
@@ -152,7 +173,7 @@
       <single>
         <title>Total Events $type_printable$</title>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(total.$type$_events)`) AS $type$_events WHERE `set_cribl_metrics_index` $host$ $type$put="$full_selected$" $worker_group_metric_pre_filter$ BY group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats sum(`set_cribl_metrics_prefix(total.$type$_events)`) AS $type$_events WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $type$put="$full_selected$" $worker_group_metric_pre_filter$ BY group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | stats sum($type$_events) AS $type$_events</query>
           <earliest>$time.earliest$</earliest>
@@ -168,7 +189,7 @@
       <chart>
         <title>Total Bytes $type_printable$ over Time</title>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(total.$type$_bytes)`) AS $type$_bytes WHERE `set_cribl_metrics_index` $host$ $type$put="$full_selected$" $worker_group_metric_pre_filter$ span=auto BY $type$put group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats sum(`set_cribl_metrics_prefix(total.$type$_bytes)`) AS $type$_bytes WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $type$put="$full_selected$" $worker_group_metric_pre_filter$ span=auto BY $type$put group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | timechart sum($type$_bytes) BY $type$put</query>
           <earliest>$time.earliest$</earliest>
@@ -189,7 +210,7 @@
       <chart>
         <title>Total Events $type_printable$ over Time</title>
         <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(total.$type$_events)`) AS $type$_events WHERE `set_cribl_metrics_index` $host$ $type$put="$full_selected$" $worker_group_metric_pre_filter$ span=auto BY $type$put group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats sum(`set_cribl_metrics_prefix(total.$type$_events)`) AS $type$_events WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $type$put="$full_selected$" $worker_group_metric_pre_filter$ span=auto BY $type$put group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | timechart sum($type$_events) BY $type$put</query>
           <earliest>$time.earliest$</earliest>
@@ -225,7 +246,7 @@
       <chart>
         <title>Health of $type_printable$puts over Time</title>
         <search>
-          <query>| mstats max(`set_cribl_metrics_prefix(health.$type$puts)`) AS $type$put_health WHERE `set_cribl_metrics_index` $host$ $type$put="$full_selected$" $worker_group_metric_pre_filter$ span=auto BY $type$put group fillnull_value=`set_unknown_worker_group_value`
+          <query>| mstats max(`set_cribl_metrics_prefix(health.$type$puts)`) AS $type$put_health WHERE `set_cribl_metrics_index` $environment_filter$ $host$ $type$put="$full_selected$" $worker_group_metric_pre_filter$ span=auto BY $type$put group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
 | timechart max($type$put_health) BY $type$put</query>
           <earliest>$time.earliest$</earliest>
@@ -308,7 +329,7 @@
       <event>
         <title>Events for Channel "$type$put:$selected$"</title>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=$type$put:$selected$ $levels$</query>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=$type$put:$selected$ $levels$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>

--- a/criblvision/default/data/ui/views/stats.xml
+++ b/criblvision/default/data/ui/views/stats.xml
@@ -13,6 +13,27 @@
         <latest>now</latest>
       </default>
     </input>
+    <input type="dropdown" token="environment" searchWhenChanged="true">
+      <label>Environment</label>
+      <choice value="*">All Environments</choice>
+      <fieldForLabel>environment</fieldForLabel>
+      <fieldForValue>hosts</fieldForValue>
+      <search>
+        <query>| `dashboard_cribl_environment_filter`</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition label="All Environments">
+          <set token="environment_filter"></set>
+        </condition>
+        <condition>
+          <set token="environment_filter">host IN ($environment$)</set>
+        </condition>
+      </change>
+      <default>*</default>
+      <initialValue>*</initialValue>
+    </input>
     <input type="dropdown" token="worker_group" searchWhenChanged="true">
       <label>Worker Group / Single</label>
       <choice value="all_instances">All Instances</choice>
@@ -21,7 +42,7 @@
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>worker_group</fieldForValue>
       <search>
-        <query>| `dashboard_worker_group_filter`</query>
+        <query>| `dashboard_worker_group_filter($environment_filter|s$)`</query>
         <earliest>-24h@h</earliest>
         <latest>now</latest>
       </search>
@@ -47,7 +68,7 @@
       <fieldForLabel>label</fieldForLabel>
       <fieldForValue>host</fieldForValue>
       <search>
-        <query>| `dashboard_host_filter($worker_group_event_filter|s$)`</query>
+        <query>| `dashboard_host_filter($environment_filter|s$ $worker_group_event_filter|s$)`</query>
         <earliest>$time.earliest$</earliest>
         <latest>$time.latest$</latest>
       </search>
@@ -113,7 +134,7 @@
       <chart>
         <title>CPU Usage</title>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(cpuPerc) as cpuPerc $splitby$</query>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(cpuPerc) as cpuPerc $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
@@ -134,7 +155,7 @@
       <chart>
         <title>Memory Usage</title>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(mem.ext) as memExt last(mem.heap) as memHeap last(mem.rss) as memRss $splitby$</query>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(mem.ext) as memExt last(mem.heap) as memHeap last(mem.rss) as memRss $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
@@ -153,7 +174,7 @@
       <chart>
         <title>Active vs Blocked Event Processors</title>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(activeEP) as activeEP last(blockedEP) as blockedEP $splitby$</query>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(activeEP) as activeEP last(blockedEP) as blockedEP $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
@@ -174,7 +195,7 @@
       <chart>
         <title>Event Stats</title>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(droppedEvents) as DroppedEvents last(outEvents) as outEvents last(inEvents) as inEvents $splitby$</query>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(droppedEvents) as DroppedEvents last(outEvents) as outEvents last(inEvents) as inEvents $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
@@ -193,7 +214,7 @@
       <chart>
         <title>Persistent Queue Stats</title>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $host$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(pqInBytes) as pqInBytes last(pqOutBytes) as pqOutBytes last(pqTotalBytes) as pqTotalBytes $splitby$</query>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(pqInBytes) as pqInBytes last(pqOutBytes) as pqOutBytes last(pqTotalBytes) as pqTotalBytes $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>

--- a/criblvision/default/data/ui/views/welcome.xml
+++ b/criblvision/default/data/ui/views/welcome.xml
@@ -157,6 +157,12 @@
                 </td>
                 <td>Change the <code>cribl.logstream</code> value before <code>.$metric_name$</code> if you have changed the default namespace used for your Cribl metrics internal Source.</td>
               </tr>
+              <tr>
+                <td>
+                  <code>set_cribl_environment_field_name</code>
+                </td>
+                <td>(Optional) Set this macro definition to the name of the field that specifies the environment a Cribl Stream instance belongs to.</td>
+              </tr>
             </table>
             <p>For manual configuration of the macro definitions through the CLI, append and update the following to <code>$SPLUNK_HOME/etc/apps/criblvision/local/macros.conf</code> on standalone Search Heads or <code>$SPLUNK_HOME/etc/shcluster/apps/criblvision/local/macros.conf</code> on Search Head Deployers for a Search Head Cluster:</p>
             <pre>[set_cribl_internal_log_index]
@@ -169,7 +175,10 @@ definition = sourcetype IN (cribl)
 definition = index=cribl_metrics
 
 [set_cribl_metrics_prefix(1)]
-definition = cribl.logstream.$metric_name$</pre>
+definition = cribl.logstream.$metric_name$
+
+[set_cribl_environment_field_name]
+definition = env</pre>
           </div>
           <hr class="break-line" />
           <div>

--- a/criblvision/default/data/ui/views/welcome.xml
+++ b/criblvision/default/data/ui/views/welcome.xml
@@ -4,13 +4,10 @@
     <panel>
       <html>
         <style>
-          h1, h2, h3 {
+          h2, h3 {
             font-family: Arial !important;
             font-weight: bold !important;
             padding-bottom: 0.25em;
-          }
-          h1 {
-            font-size: 48pt !important;
           }
           h2 {
             font-size: 32pt !important;
@@ -57,6 +54,12 @@
             background-color: white;
             padding: 1em;
           }
+          .welcome-header {
+            font-size: 48pt !important;
+            font-family: Arial !important;
+            font-weight: bold !important;
+            padding-bottom: 0.25em;
+          }
         </style>
       </html>
     </panel>
@@ -64,8 +67,8 @@
   <row>
     <panel>
       <html>
-        <div class="welcome-container">
-          <h1>CriblVision</h1>
+        <div class="welcome-container welcome-header">
+          <p>CriblVision</p>
         </div>
       </html>
     </panel>

--- a/criblvision/default/macros.conf
+++ b/criblvision/default/macros.conf
@@ -24,7 +24,7 @@ iseval = 0
 [dashboard_cribl_environment_filter]
 definition = inputlookup cribl_stream assets\
 | stats values(host) AS hosts BY `set_cribl_environment_field_name`\
-| eval hosts = mvjoin(hosts, ",")\
+| eval hosts = "\"".mvjoin(hosts, "\", \"")"\""\
 | rename `set_cribl_environment_field_name` AS environment
 iseval = 0
 

--- a/criblvision/default/macros.conf
+++ b/criblvision/default/macros.conf
@@ -1,5 +1,9 @@
 ### GENERAL MACROS ###
 
+[set_cribl_environment_field_name]
+definition = env
+iseval = 0
+
 [set_cribl_internal_log_index]
 definition = index=cribl_logs
 iseval = 0
@@ -15,10 +19,6 @@ iseval = 0
 [set_cribl_metrics_prefix(1)]
 args = metric_name
 definition = cribl.logstream.$metric_name$
-iseval = 0
-
-[set_environment_field_name]
-definition = env
 iseval = 0
 
 [dashboard_host_filter]

--- a/criblvision/default/macros.conf
+++ b/criblvision/default/macros.conf
@@ -17,6 +17,10 @@ args = metric_name
 definition = cribl.logstream.$metric_name$
 iseval = 0
 
+[set_environment_field_name]
+definition = env
+iseval = 0
+
 [dashboard_host_filter]
 definition = tstats count WHERE `set_cribl_internal_log_index` `set_cribl_log_sourcetype` BY host\
 | lookup cribl_stream_assets host AS host\

--- a/criblvision/default/macros.conf
+++ b/criblvision/default/macros.conf
@@ -46,6 +46,15 @@ definition = inputlookup cribl_stream_assets\
 | where instance_type == "worker"\
 | stats count BY worker_group\
 | eval label = "Worker Group: ".worker_group
+iseval = 0
+
+[dashboard_worker_group_filter(1)]
+args = worker_group_filter
+definition = inputlookup cribl_stream_assets\
+| search instance_type="worker" $worker_group_filter$\
+| stats count BY worker_group\
+| eval label = "Worker Group: ".worker_group
+iseval = 0
 
 ### ALERT MACROS ###
 

--- a/criblvision/default/macros.conf
+++ b/criblvision/default/macros.conf
@@ -21,6 +21,13 @@ args = metric_name
 definition = cribl.logstream.$metric_name$
 iseval = 0
 
+[dashboard_cribl_environment_filter]
+definition = inputlookup cribl_stream assets\
+| stats values(host) AS hosts BY `set_cribl_environment_field_name`\
+| eval hosts = mvjoin(hosts, ",")\
+| rename `set_cribl_environment_field_name` AS environment
+iseval = 0
+
 [dashboard_host_filter]
 definition = tstats count WHERE `set_cribl_internal_log_index` `set_cribl_log_sourcetype` BY host\
 | lookup cribl_stream_assets host AS host\

--- a/criblvision/default/savedsearches.conf
+++ b/criblvision/default/savedsearches.conf
@@ -63,12 +63,18 @@ search = | tstats latest(_time) AS latest_event_time WHERE `set_cribl_internal_l
     [ search `set_cribl_internal_log_index` `set_cribl_log_sourcetype` channel=ShutdownMgr\
     | stats latest(_time) AS latest_shutdown_time BY host ]\
 | rename L.* AS * R.latest_shutdown_time AS latest_shutdown_time\
-| table host group latest_event_time latest_metric_time latest_shutdown_time\
+| join type=left left=L right=R WHERE L.host=R.host\
+    [ search `set_cribl_internal_log_index` `set_cribl_log_sourcetype` `set_cribl_environment_field_name`=*\
+    | stats count BY host `set_cribl_environment_field_name` ]\
+| rename L.* AS * R.`set_cribl_environment_field_name` AS `set_cribl_environment_field_name`\
+| table host `set_cribl_environment_field_name` group latest_event_time latest_metric_time latest_shutdown_time\
 | eval instance_type = case(isnull(latest_metric_time), "leader", group == `set_unknown_worker_group_value`, "single", isnotnull(latest_event_time) AND isnotnull(latest_metric_time), "worker", true(), "unknown")\
+| eval `set_cribl_environment_field_name` = coalesce(`set_cribl_environment_field_name`, `set_unknown_worker_group_value`)\
 | eval worker_group = if(isnull(group) OR len(group) == 0, `set_unknown_worker_group_value`, group), latest_activity_time = max(latest_event_time, latest_metric_time)\
-| table host instance_type worker_group latest_activity_time latest_shutdown_time\
+| table host `set_cribl_environment_field_name` instance_type worker_group latest_activity_time latest_shutdown_time\
 | inputlookup cribl_stream_assets append=true\
-| stats max(latest_activity_time) AS latest_activity_time max(latest_shutdown_time) AS latest_shutdown_time BY host instance_type worker_group\
+| stats values(`set_cribl_environment_field_name`) AS `set_cribl_environment_field_name` max(latest_activity_time) AS latest_activity_time max(latest_shutdown_time) AS latest_shutdown_time BY host instance_type worker_group\
+| eval `set_cribl_environment_field_name` = if(mvcount(`set_cribl_environment_field_name`) > 1, mvfilter(`set_cribl_environment_field_name` != `set_unknown_worker_group_value`), `set_cribl_environment_field_name`), `set_cribl_environment_field_name` = mvjoin(`set_cribl_environment_field_name`, ",")\
 | eval status = case(abs(latest_activity_time - latest_shutdown_time) < `set_shutdown_activity_difference_secs`, "shutdown", relative_time(now(), `set_missing_asset_relative_time`) < latest_activity_time, "active", true(), "missing")\
 | outputlookup cribl_stream_assets
 


### PR DESCRIPTION
Added support for environment filtering across the CriblVision dashboards:
* Added the `set_cribl_environment_field_name` macro to specify the name of the Cribl environment variable name
* Updated the Populate Cribl Stream Assets Lookup report to include the environment of each Cribl Stream asset
* Updated all dashboards with an "Environment" drop down to select the environment