### PR TITLE
Updating Alerts

### DIFF
--- a/criblvision/default/app.conf
+++ b/criblvision/default/app.conf
@@ -4,7 +4,7 @@
 
 [id]
 name = criblvision
-version = 3.2.0
+version = 3.2.1
 
 [install]
 is_configured = false
@@ -17,7 +17,7 @@ setup_view = criblvision_setup_page
 [launcher]
 author = Johan Woger
 description = The Splunk on Stream app provides insight into your Cribl Stream Environment based on Stream's internal logs and metrics. The dashboards included in this app will help you quickly identify and troubleshoot issue with your deployment. 
-version = 3.2.0
+version = 3.2.1
 
 [package]
 id = criblvision

--- a/criblvision/default/savedsearches.conf
+++ b/criblvision/default/savedsearches.conf
@@ -249,7 +249,8 @@ search = | mstats sum(`set_cribl_metrics_prefix(total.out_events)`) AS out_event
 | fillnull value=0 out_events\
 | stats count(eval(out_events == 0)) AS no_events count AS total BY group output\
 | eval no_events_pct = round((no_events / total) * 100, 2), instance_type = if(group == `set_unknown_worker_group_value`, "single", "worker")\
-| where no_events_pct > `set_alert_threshold_no_destination_thruput_pct`
+| where no_events_pct > `set_alert_threshold_no_destination_thruput_pct`\
+| table instance_type group output no_events_pct
 
 [CriblVision Alert - Opened Connections Over Threshold]
 disabled = 1

--- a/criblvision/default/savedsearches.conf
+++ b/criblvision/default/savedsearches.conf
@@ -129,7 +129,8 @@ search = `set_cribl_internal_log_index` message="_raw stats"\
 | stats max(cpuPerc) AS cpu_pct BY _time host instance_type worker_group\
 | stats count(eval(cpu_pct > `set_alert_unhealthy_cpu_usage_pct`)) AS unhealthy_cpu_usage count AS total BY host instance_type worker_group\
 | eval unhealthy_cpu_usage_pct = round((unhealthy_cpu_usage / total) * 100, 2)\
-| where unhealthly_cpu_usage_pct > `set_alert_threshold_unhealthy_cpu_usage_pct`
+| where unhealthy_cpu_usage_pct > `set_alert_threshold_unhealthy_cpu_usage_pct`\
+| table host instance_type worker_group unhealthy_cpu_usage_pct
 
 [CriblVision Alert - Cluster Communication Errors]
 disabled = 1

--- a/criblvision/default/savedsearches.conf
+++ b/criblvision/default/savedsearches.conf
@@ -397,7 +397,8 @@ request.ui_dispatch_view = search
 search = | mstats max(`set_cribl_metrics_prefix(health.inputs)`) AS health WHERE `set_cribl_metrics_index` `set_alert_ignored_sources` BY input group fillnull_value=`set_unknown_worker_group_value` span=1m\
 | stats count(eval(health == 2)) AS troubled_count count AS total BY group input\
 | eval unhealthy_pct = (troubled_count / total) * 100, instance_type = if(group == `set_unknown_worker_group_value`, "single", "worker")\
-| where unhealthy_pct > `set_alert_threshold_unhealthy_sources_pct`
+| where unhealthy_pct > `set_alert_threshold_unhealthy_sources_pct`\
+| table instance_type group input unhealthy_pct
 
 [CriblVision Alert - Worker Process Restarted]
 disabled = 1

--- a/criblvision/default/savedsearches.conf
+++ b/criblvision/default/savedsearches.conf
@@ -102,7 +102,8 @@ request.ui_dispatch_view = search
 search = `set_cribl_internal_log_index` `set_cribl_log_sourcetype` instance_type!=leader channel=output:* message="sending is blocked*"\
 | rex field=channel "output:(?<output>.*)"\
 | stats count AS blocked_destination_count BY host instance_type worker_group output\
-| where blocked_destination_count > `set_alert_threshold_blocked_destinations`
+| where blocked_destination_count > `set_alert_threshold_blocked_destinations`\
+| table host instance_type worker_group output
 
 [CriblVision Alert - CPU Usage Over Threshold]
 disabled = 1

--- a/criblvision/default/savedsearches.conf
+++ b/criblvision/default/savedsearches.conf
@@ -223,7 +223,8 @@ search = | mstats sum(`set_cribl_metrics_prefix(total.in_events)`) AS in_events 
 | fillnull value=0 in_events\
 | stats count(eval(in_events == 0)) AS no_events count AS total BY group input\
 | eval no_events_pct = round((no_events / total) * 100, 2), instance_type = if(group == `set_unknown_worker_group_value`, "single", "worker")\
-| where no_events_pct > `set_alert_threshold_no_source_thruput_pct`
+| where no_events_pct > `set_alert_threshold_no_source_thruput_pct`\
+| table instance_type group input no_events_pct
 
 [CriblVision Alert - No Output From Destinations]
 disabled = 1

--- a/criblvision/default/savedsearches.conf
+++ b/criblvision/default/savedsearches.conf
@@ -328,7 +328,8 @@ search = `set_cribl_internal_log_index` message="_raw stats"\
 | stats max(mem.rss) AS mem_rss BY _time host instance_type worker_group\
 | stats count(eval(mem_rss > `set_alert_lower_limit_unhealthy_memory_usage_mb` AND mem_rss <= `set_alert_upper_limit_unhealthy_memory_usage_mb`)) AS unhealthy_memory_rss_usage count AS total BY host instance_type worker_group\
 | eval unhealthy_memory_rss_usage_pct = round(( unhealthy_memory_rss_usage / total) * 100, 2)\
-| where unhealthy_memory_rss_usage_pct > `set_alert_threshold_unhealthy_memory_usage_mb_pct`
+| where unhealthy_memory_rss_usage_pct > `set_alert_threshold_unhealthy_memory_usage_mb_pct`\
+| table host instance_type worker_group unhealthy_memory_rss_usage_pct
 
 [CriblVision Alert - Shutdown Cribl Stream Assets]
 disabled = 1

--- a/criblvision/default/savedsearches.conf
+++ b/criblvision/default/savedsearches.conf
@@ -372,7 +372,8 @@ request.ui_dispatch_view = search
 search = | mstats max(`set_cribl_metrics_prefix(health.outputs)`) AS health WHERE `set_cribl_metrics_index` `set_alert_ignored_destinations` BY output group fillnull_value=`set_unknown_worker_group_value` span=1m\
 | stats count(eval(health == 2)) AS troubled_count count AS total BY group output\
 | eval unhealthy_pct = (troubled_count / total) * 100, instance_type = if(group == `set_unknown_worker_group_value`, "single", "worker")\
-| where unhealthy_pct > `set_alert_threshold_unhealthy_destinations_pct`
+| where unhealthy_pct > `set_alert_threshold_unhealthy_destinations_pct`\
+| table instance_type group output unhealthy_pct
 
 [CriblVision Alert - Unhealthy Sources]
 disabled = 1

--- a/criblvision/default/savedsearches.conf
+++ b/criblvision/default/savedsearches.conf
@@ -301,7 +301,8 @@ request.ui_dispatch_view = search
 search = `set_cribl_internal_log_index` `set_cribl_log_sourcetype` instance_type!=leader channel=SourcePQ:* message="initializing persistent queue"\
 | rex field=channel "SourcePQ:(?<input>.*)"\
 | stats count AS pq_initialized_count BY worker_group input\
-| where pq_initialized_count > `set_alert_threshold_pq_initialized_count`
+| where pq_initialized_count > `set_alert_threshold_pq_initialized_count`\
+| table worker_group input
 
 [CriblVision Alert - RSS Memory Usage Within Threshold]
 disabled = 1

--- a/criblvision/default/savedsearches.conf
+++ b/criblvision/default/savedsearches.conf
@@ -276,7 +276,8 @@ search = `set_cribl_internal_log_index` `set_cribl_log_sourcetype` message="_raw
 | stats sum(openCxn) AS open_connections BY _time host instance_type worker_group\
 | stats count(eval(open_connections > `set_alert_unhealthy_open_connections_count`)) AS unhealthy_open_connections_count count AS total BY host instance_type worker_group\
 | eval unhealthy_open_connections_pct = round(( unhealthy_open_connections_count / total) * 100, 2)\
-| where unhealthy_open_connections_pct > `set_alert_threshold_unhealthy_open_connections_pct`
+| where unhealthy_open_connections_pct > `set_alert_threshold_unhealthy_open_connections_pct`\
+| table host instance_type worker_group unhealthy_open_connections_pct
 
 [CriblVision Alert - Persistent Queue Initialized]
 disabled = 1


### PR DESCRIPTION
Fixing a typo in the `CPU Usage Over Threshold` alert and removing unnecessary fields from alert outputs.