### PR TITLE
Fixing Memory Usage Calculations

### DIFF
--- a/criblvision/default/app.conf
+++ b/criblvision/default/app.conf
@@ -4,7 +4,7 @@
 
 [id]
 name = criblvision
-version = 3.2.1
+version = 3.2.2
 
 [install]
 is_configured = false
@@ -17,7 +17,7 @@ setup_view = criblvision_setup_page
 [launcher]
 author = Johan Woger
 description = The Splunk on Stream app provides insight into your Cribl Stream Environment based on Stream's internal logs and metrics. The dashboards included in this app will help you quickly identify and troubleshoot issue with your deployment. 
-version = 3.2.1
+version = 3.2.2
 
 [package]
 id = criblvision

--- a/criblvision/default/data/ui/views/health_check.xml
+++ b/criblvision/default/data/ui/views/health_check.xml
@@ -168,8 +168,10 @@
           <done>
             <eval token="max_memRss">tostring($result.max_memRss$, "commas")</eval>
           </done>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats" 
-| stats avg(mem.rss) AS memRss</query>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats"
+| bin _time span=1m
+| stats sum(mem.rss) AS memRss BY _time host instance_type worker_group
+| stats avg(memRss) AS memRss</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
@@ -202,13 +204,13 @@
     <panel>
       <title>CPU Perc (Avg) Breakdown by Host over Time</title>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_cpu_perc$">
           <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats" 
 | timechart avg(cpuPerc) BY host</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Avg CPU (%)</option>
         <option name="charting.chart">area</option>
@@ -252,13 +254,15 @@
     <panel>
       <title>Memory Usage (Avg) Breakdown by Host over Time</title>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_mem_usage$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats" 
-| timechart avg(mem.rss) BY host</query>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats"
+| bin _time span=1m 
+| stats sum(mem.rss) AS memRss BY _time host instance_type worker_group
+| timechart avg(memRss) BY host</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Avg Memory Usage (MB)</option>
         <option name="charting.chart">area</option>
@@ -272,20 +276,22 @@
       <title>Memory Usage (Avg) Breakdown by Host</title>
       <table>
         <search depends="$show_mem_usage$">
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats" 
-| stats avg(mem.rss) AS memRss BY host instance_type worker_group
-| lookup cribl_stream_assets host OUTPUTNEW environment
-| rename host AS Host environment AS Environment instance_type AS "Instance Type" worker_group AS "Worker Group" memRss AS "Memory Usage"
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats"
+| bin _time span=1m 
+| stats sum(mem.rss) AS memRss BY _time host instance_type worker_group 
+| stats avg(memRss) AS memRss BY host instance_type worker_group 
+| lookup cribl_stream_assets host OUTPUTNEW environment 
+| rename host AS Host environment AS Environment instance_type AS "Instance Type" worker_group AS "Worker Group" memRss AS "Memory Usage" 
 | `get_environment_hosts(Environment)`</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
         <option name="drilldown">cell</option>
         <option name="refresh.display">progressbar</option>
-        <fields>Host,Environment,"Instance Type","Worker Group","Memory Usage"</fields>
         <format type="number" field="Memory Usage">
           <option name="unit">MB</option>
         </format>
+        <fields>["Host","Environment","Instance Type","Worker Group","Memory Usage"]</fields>
         <drilldown>
           <eval token="worker_group_drilldown">if('row.Instance Type' == "single", "all_single", 'row.Worker Group')</eval>
           <link target="_blank">/app/criblvision/stats?form.time.earliest=$time.earliest$&amp;form.time.latest=$time.latest$&amp;form.environment=$row.hosts$&amp;form.host=$row.Host$&amp;form.worker_group=$worker_group_drilldown$</link>
@@ -432,6 +438,7 @@
     <panel>
       <title>Unhealthy Sources over Time</title>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_unhealthy_sources$">
           <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ $unhealthy_sources$ span=auto BY input group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
@@ -439,7 +446,6 @@
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisLabelsY.majorUnit">1</option>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Status</option>
@@ -493,6 +499,7 @@
     <panel>
       <title>Unhealthy Destinations over Time</title>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_unhealthy_destinations$">
           <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ $unhealthy_destinations$ span=auto BY output group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
@@ -500,7 +507,6 @@
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisLabelsY.majorUnit">1</option>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Status</option>
@@ -573,13 +579,13 @@
     <panel id="total_pq_size_timeline">
       <title>PQ Size by Host (Last 15 Minutes)</title>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_total_pq_size$">
           <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ span=auto BY host prestats=true
 | timechart sum(`set_cribl_metrics_prefix("pq.queue_size")`) BY host</query>
           <earliest>-15m</earliest>
           <latest>now</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">PQ Size (B)</option>
         <option name="charting.chart">line</option>
@@ -595,7 +601,7 @@
       <table>
         <search depends="$show_total_pq_size$">
           <query>| mstats latest(`set_cribl_metrics_prefix("pq.queue_size")`) AS total_pq_size WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ BY host group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$ total_pq_size > 0
+| search $worker_group_metric_filter$ total_pq_size &gt; 0
 | lookup cribl_stream_assets host OUTPUTNEW environment instance_type
 | rename host AS Host environment AS Environment instance_type AS "Instance Type" group AS "Worker Group" total_pq_size AS "Total PQ Size"
 | `get_environment_hosts(Environment)`</query>
@@ -736,13 +742,13 @@
     <panel id="worker_process_reset_timeline">
       <title>Worker Process Restarts by Host over Time</title>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_worker_process_restarts$">
           <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=cribl* message="restarting worker process" 
 | timechart count BY host</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Worker Process Restarts</option>
         <option name="charting.chart">area</option>
@@ -772,6 +778,7 @@
     <panel id="backpressured_destinations_timeline">
       <title>Destinations with Backpressure over Time</title>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_backpressured_destinations$">
           <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) AS back_pressured WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ BY output group span=auto fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$ back_pressured!=0
@@ -779,7 +786,6 @@
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Back Pressure</option>
         <option name="charting.axisY.minimumNumber">0</option>
@@ -819,6 +825,7 @@
     <panel id="blocked_destinations_timeline">
       <title>Blocked Destinations over Time</title>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_blocked_destinations$">
           <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) AS blocked WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ BY output group span=auto fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$ blocked!=0
@@ -826,7 +833,6 @@
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Back Pressure</option>
         <option name="charting.axisY.abbreviation">none</option>
@@ -867,6 +873,7 @@
     <panel id="pq_engaged_timeline">
       <title>Destinations with PQ Engaged over Time (Last 15 Minutes)</title>
       <chart>
+        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_pq_engaged$">
           <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_engaged WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ BY output host group span=auto fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$
@@ -875,7 +882,6 @@
           <earliest>-15m</earliest>
           <latest>now</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">PQs Engaged</option>
         <option name="charting.chart">area</option>
@@ -891,7 +897,7 @@
       <table>
         <search depends="$show_pq_engaged$">
           <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_engaged WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ BY output host group fillnull_value=`set_unknown_worker_group_value`
-| search $worker_group_metric_filter$ pq_engaged > 0
+| search $worker_group_metric_filter$ pq_engaged &gt; 0
 | rex field=output "(?&lt;technology&gt;[^:]+):(?&lt;output&gt;.*)"
 | lookup cribl_stream_assets host OUTPUTNEW environment instance_type
 | table technology output host environment instance_type group

--- a/criblvision/default/data/ui/views/stats.xml
+++ b/criblvision/default/data/ui/views/stats.xml
@@ -136,12 +136,12 @@
     <panel>
       <chart>
         <title>CPU Usage</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(cpuPerc) as cpuPerc $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">CPU Usage (%)</option>
         <option name="charting.chart">area</option>
@@ -157,12 +157,15 @@
     <panel>
       <chart>
         <title>Memory Usage</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
-          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(mem.ext) as memExt last(mem.heap) as memHeap last(mem.rss) as memRss $splitby$</query>
+          <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats"
+| bin _time span=1m
+| stats sum(mem.*) AS mem.* BY _time
+| timechart $span$ last(mem.ext) as memExt last(mem.heap) as memHeap last(mem.rss) as memRss $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Memory Usage (MB)</option>
         <option name="charting.chart">area</option>
@@ -176,12 +179,12 @@
     <panel>
       <chart>
         <title>Active vs Blocked Event Processors</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(activeEP) as activeEP last(blockedEP) as blockedEP $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Count</option>
         <option name="charting.chart">area</option>
@@ -197,12 +200,12 @@
     <panel>
       <chart>
         <title>Event Stats</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(droppedEvents) as DroppedEvents last(outEvents) as outEvents last(inEvents) as inEvents $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Count</option>
         <option name="charting.chart">area</option>
@@ -216,12 +219,12 @@
     <panel>
       <chart>
         <title>Persistent Queue Stats</title>
+        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats" | timechart $span$ last(pqInBytes) as pqInBytes last(pqOutBytes) as pqOutBytes last(pqTotalBytes) as pqTotalBytes $splitby$</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
-        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Size (B)</option>
         <option name="charting.chart">area</option>

--- a/criblvision/default/savedsearches.conf
+++ b/criblvision/default/savedsearches.conf
@@ -324,8 +324,9 @@ relation = greater than
 request.ui_dispatch_app = criblvision
 request.ui_dispatch_view = search
 search = `set_cribl_internal_log_index` message="_raw stats"\
-| bin _time span=1m \
-| stats max(mem.rss) AS mem_rss BY _time host instance_type worker_group\
+| bin _time span=1m\
+| stats sum(mem.rss) AS mem_rss BY _time host instance_type worker_group\
+| stats max(mem_rss) AS mem_rss BY _time host instance_type worker_group\
 | stats count(eval(mem_rss > `set_alert_lower_limit_unhealthy_memory_usage_mb` AND mem_rss <= `set_alert_upper_limit_unhealthy_memory_usage_mb`)) AS unhealthy_memory_rss_usage count AS total BY host instance_type worker_group\
 | eval unhealthy_memory_rss_usage_pct = round(( unhealthy_memory_rss_usage / total) * 100, 2)\
 | where unhealthy_memory_rss_usage_pct > `set_alert_threshold_unhealthy_memory_usage_mb_pct`\


### PR DESCRIPTION
Memory usage was previously being calculated per worker process, which was making memory usage look lower than it was. Added in logic to sum the memory usage across worker processes before performing further aggregations in the following locations:
- The Health Check dashboard
- The Stats dashboard
- The Memory Usage Within Threshold alert