### PR TITLE
Bytes Unit Dashboard Filter

### DIFF
--- a/criblvision/default/data/ui/views/cribl_stream_license_metrics.xml
+++ b/criblvision/default/data/ui/views/cribl_stream_license_metrics.xml
@@ -5,6 +5,29 @@
     <earliest>$time.earliest$</earliest>
     <latest>$time.latest$</latest>
   </search>
+  <search id="bytes_summary_io_base_search">
+    <query>| mstats sum(`set_cribl_metrics_prefix(route.*_bytes)`) AS *_bytes WHERE `set_cribl_metrics_index` $environment_filter$
+| foreach *_bytes [ eval `process_bytes(&lt;&lt;FIELD&gt;&gt;, "$bytes_unit_abbreviated_label$")` ]
+| eval bytes_reduction = out_bytes - in_bytes, bytes_reduction_pct = (bytes_reduction / in_bytes) * -100</query>
+    <earliest>$time.earliest$</earliest>
+    <latest>$time.latest$</latest>
+  </search>
+  <search id="bytes_time_summary_io_base_search">
+    <query>| mstats sum(`set_cribl_metrics_prefix(route.*_bytes)`) AS *_bytes WHERE `set_cribl_metrics_index` $environment_filter$ span=auto
+| foreach *_bytes [ eval `process_bytes(&lt;&lt;FIELD&gt;&gt;, "$bytes_unit_abbreviated_label$")` ]
+| rename in_bytes AS "$bytes_unit_label$ In" out_bytes AS "$bytes_unit_label$ Out"</query>
+    <earliest>$time.earliest$</earliest>
+    <latest>$time.latest$</latest>
+  </search>
+  <search>
+    <done>
+      <set token="init_bytes_unit_abbreviated_label">$result.bytes_unit_abbreviated_label$</set>
+    </done>
+    <query>| makeresults | eval bytes_unit_abbreviated_label = upper(`set_bytes_unit`)
+    </query>
+    <earliest>-1m@m</earliest>
+    <latest>now</latest>
+  </search>
   <fieldset submitButton="true" autoRun="true">
     <input type="time" searchWhenChanged="false" token="time">
       <label>Time Range</label>
@@ -34,14 +57,25 @@
       <default>*</default>
       <initialValue>*</initialValue>
     </input>
-    <input type="dropdown" token="unit" searchWhenChanged="true">
-      <label>Unit</label>
-      <choice value="bytes">Bytes</choice>
-      <choice value="KB">KB</choice>
-      <choice value="MB">MB</choice>
-      <choice value="GB">GB</choice>
-      <default>GB</default>
-      <initialValue>GB</initialValue>
+    <input type="dropdown" token="bytes_unit" searchWhenChanged="true">
+      <label>Bytes Unit</label>
+      <default>$init_bytes_unit_abbreviated_label$</default>
+      <initialValue>$init_bytes_unit_abbreviated_label$</initialValue>
+      <fieldForLabel>unit</fieldForLabel>
+      <fieldForValue>abbreviated_unit</fieldForValue>
+      <search>
+        <query>| inputlookup bytes_units</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition>
+          <eval token="bytes_unit_abbreviated_label">value</eval>
+          <eval token="bytes_unit_label">label</eval>
+          <eval token="bytes_precision_single">if(lower(value) == "b", "0", "0.000")</eval>
+          <eval token="bytes_precision_table">if(lower(value) == "b", "0", "3")</eval>
+        </condition>
+      </change>
     </input>
     <input type="link" token="how_to_use">
       <label>How to Use</label>
@@ -71,98 +105,68 @@
   </row>
   <row>
     <panel>
-      <title>Cribl Stream $unit$ In</title>
+      <title>Cribl Stream $bytes_unit_label$ In</title>
       <single>
-        <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(route.in_bytes)`) prestats=true WHERE `set_cribl_metrics_index` $environment_filter$ span=1h
-| stats sum(`set_cribl_metrics_prefix(route.in_bytes)`) AS bytes
-| eval KB=round(bytes/1024, 4)
-| eval MB=round(bytes/1024/1024, 4)
-| eval GB=round(bytes/1024/1024/1024, 4)
-| fields $unit$</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-          <sampleRatio>1</sampleRatio>
-        </search>
-        <option name="colorMode">none</option>
-        <option name="drilldown">none</option>
-        <option name="numberPrecision">0.00</option>
-        <option name="rangeColors">["0xdc4e41","0x27efe6"]</option>
-        <option name="rangeValues">[0]</option>
-        <option name="refresh.display">progressbar</option>
-        <option name="underLabel">$unit$ IN</option>
-        <option name="unit">$unit$</option>
-        <option name="useColors">1</option>
-      </single>
-    </panel>
-    <panel>
-      <title>Cribl Stream $unit$ Out</title>
-      <single>
-        <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(route.out_bytes)`) prestats=true WHERE `set_cribl_metrics_index` $environment_filter$ span=1h
-| stats sum(`set_cribl_metrics_prefix(route.out_bytes)`) AS bytes
-| eval KB=round(bytes/1024, 4)
-| eval MB=round(bytes/1024/1024, 4)
-| eval GB=round(bytes/1024/1024/1024, 4)
-| fields $unit$</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-          <sampleRatio>1</sampleRatio>
-        </search>
-        <option name="drilldown">none</option>
-        <option name="numberPrecision">0.00</option>
-        <option name="rangeColors">["0xdc4e41","0xa303df"]</option>
-        <option name="rangeValues">[0]</option>
-        <option name="refresh.display">progressbar</option>
-        <option name="underLabel">$unit$ OUT</option>
-        <option name="unit">$unit$</option>
-        <option name="useColors">1</option>
-      </single>
-    </panel>
-    <panel>
-      <title>Cribl Stream $unit$ Volume Reduction</title>
-      <single>
-        <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(route.*_bytes)`) AS bytes_* WHERE `set_cribl_metrics_index` $environment_filter$
-| eval KB_in=round(bytes_in/1024, 4), KB_out=round(bytes_out/1024, 4)
-| eval MB_in=round(bytes_in/1024/1024, 4), MB_out=round(bytes_out/1024/1024, 4)
-| eval GB_in=round(bytes_in/1024/1024/1024, 4), GB_out=round(bytes_out/1024/1024/1024, 4)
-| fields $unit$_in $unit$_out
-| eval Volume_Reduction = $unit$_out - $unit$_in
-| fields Volume_Reduction</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-          <sampleRatio>1</sampleRatio>
+        <search base="bytes_summary_io_base_search">
+          <query>
+| table in_bytes</query>
         </search>
         <option name="colorMode">block</option>
         <option name="drilldown">none</option>
-        <option name="numberPrecision">0.00</option>
+        <option name="numberPrecision">$bytes_precision_single$</option>
+        <option name="rangeColors">["0xB88073","0xB88073"]</option>
+        <option name="rangeValues">[0]</option>
+        <option name="refresh.display">progressbar</option>
+        <option name="underLabel">$bytes_unit_label$ IN</option>
+        <option name="unit">$bytes_unit_abbreviated_label$</option>
+        <option name="useColors">1</option>
+      </single>
+    </panel>
+    <panel>
+      <title>Cribl Stream $bytes_unit_label$ Out</title>
+      <single>
+        <search base="bytes_summary_io_base_search">
+          <query>
+| table out_bytes</query>
+        </search>
+        <option name="colorMode">block</option>
+        <option name="drilldown">none</option>
+        <option name="numberPrecision">$bytes_precision_single$</option>
+        <option name="rangeColors">["0xE38E6F","0xE38E6F"]</option>
+        <option name="rangeValues">[0]</option>
+        <option name="refresh.display">progressbar</option>
+        <option name="underLabel">$bytes_unit_label$ OUT</option>
+        <option name="unit">$bytes_unit_abbreviated_label$</option>
+        <option name="useColors">1</option>
+      </single>
+    </panel>
+    <panel>
+      <title>Cribl Stream $bytes_unit_label$ Volume Reduction</title>
+      <single>
+        <search base="bytes_summary_io_base_search">
+          <query>
+| table bytes_reduction</query>
+        </search>
+        <option name="colorMode">block</option>
+        <option name="drilldown">none</option>
+        <option name="numberPrecision">$bytes_precision_single$</option>
         <option name="rangeColors">["0x53a051","0xf8be34"]</option>
         <option name="rangeValues">[0]</option>
         <option name="refresh.display">progressbar</option>
         <option name="trellis.enabled">0</option>
         <option name="trellis.scales.shared">1</option>
         <option name="trellis.size">medium</option>
-        <option name="underLabel">$unit$_out - $unit$_in</option>
-        <option name="unit">$unit$</option>
+        <option name="underLabel">$bytes_unit_label$ OUT - $bytes_unit_label$ IN</option>
+        <option name="unit">$bytes_unit_abbreviated_label$</option>
         <option name="useColors">1</option>
       </single>
     </panel>
     <panel>
-      <title>Cribl Stream $unit$ Volume Reduction %</title>
+      <title>Cribl Stream $bytes_unit_label$ Volume Reduction %</title>
       <single>
-        <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(route.*_bytes)`) AS bytes_* WHERE `set_cribl_metrics_index` $environment_filter$
-| eval KB_in=round(bytes_in/1024, 4), KB_out=round(bytes_out/1024, 4)
-| eval MB_in=round(bytes_in/1024/1024, 4), MB_out=round(bytes_out/1024/1024, 4)
-| eval GB_in=round(bytes_in/1024/1024/1024, 4), GB_out=round(bytes_out/1024/1024/1024, 4)
-| fields $unit$_in $unit$_out
-| eval Volume_Reduction = ($unit$_in - $unit$_out)
-| eval Volume_Reduction_perc = (Volume_Reduction / $unit$_in)*100
-| fields Volume_Reduction_perc</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-          <sampleRatio>1</sampleRatio>
+        <search base="bytes_summary_io_base_search">
+          <query>
+| table bytes_reduction_pct</query>
         </search>
         <option name="colorMode">block</option>
         <option name="drilldown">none</option>
@@ -170,7 +174,7 @@
         <option name="rangeColors">["0xdc4e41","0x53a051"]</option>
         <option name="rangeValues">[0]</option>
         <option name="refresh.display">progressbar</option>
-        <option name="underLabel">$unit$ Reduction %</option>
+        <option name="underLabel">$bytes_unit_label$ Reduction %</option>
         <option name="unit">%</option>
         <option name="useColors">1</option>
       </single>
@@ -178,47 +182,36 @@
   </row>
   <row>
     <panel>
-      <title>Cribl Stream $unit$ In</title>
+      <title>Cribl Stream $bytes_unit_label$ In Over Time</title>
       <chart>
-        <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(route.in_bytes)`) prestats=true WHERE `set_cribl_metrics_index` $environment_filter$ span=15m
-| timechart sum(`set_cribl_metrics_prefix(route.in_bytes)`) AS bytes span=15m
-| table _time bytes
-| eval KB=round(bytes/1024, 4)
-| eval MB=round(bytes/1024/1024, 4)
-| eval GB=round(bytes/1024/1024/1024, 4)
-| chart list($unit$) as $unit$_in over _time</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
+        <search base="bytes_time_summary_io_base_search">
+          <query>
+| table _time "$bytes_unit_label$ In"
+          </query>
         </search>
         <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.chart">area</option>
         <option name="charting.drilldown">all</option>
+        <option name="charting.fieldColors">{"$bytes_unit_label$ In":"0xB88073"}</option>
         <option name="charting.legend.placement">bottom</option>
         <option name="refresh.display">progressbar</option>
       </chart>
     </panel>
     <panel>
-      <title>Cribl Stream $unit$ Out</title>
+      <title>Cribl Stream $bytes_unit_label$ Out Over Time</title>
       <chart>
-        <search>
-          <query>| mstats sum(`set_cribl_metrics_prefix(route.out_bytes)`) prestats=true WHERE `set_cribl_metrics_index` $environment_filter$ span=15m
-| timechart sum(`set_cribl_metrics_prefix(route.out_bytes)`) AS bytes span=15m
-| table _time bytes
-| eval KB=round(bytes/1024, 4)
-| eval MB=round(bytes/1024/1024, 4)
-| eval GB=round(bytes/1024/1024/1024, 4)
-| chart list($unit$) as $unit$_out over _time</query>
-          <earliest>$time.earliest$</earliest>
-          <latest>$time.latest$</latest>
-          <sampleRatio>1</sampleRatio>
+        <search base="bytes_time_summary_io_base_search">
+          <query>
+| table _time "$bytes_unit_label$ Out"
+          </query>
         </search>
         <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.chart">area</option>
-        <option name="charting.chart.showDataLabels">minmax</option>
+        <option name="charting.chart.showDataLabels">none</option>
         <option name="charting.drilldown">none</option>
+        <option name="charting.fieldColors">{"$bytes_unit_label$ Out":"0xE38E6F"}</option>
         <option name="charting.legend.placement">bottom</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -226,7 +219,7 @@
   </row>
   <row>
     <panel>
-      <title>Splunk License $unit$ Used</title>
+      <title>Splunk License $bytes_unit_label$ Used</title>
       <input type="dropdown" token="idx_select" searchWhenChanged="true">
         <label>Include/Exclude Cribl_Stream_Metrics Index</label>
         <choice value="index=*">Include</choice>
@@ -239,13 +232,12 @@
           <query>index=_internal source=*license_usage.log type=Usage pool=*
 | rename idx AS index
 | search $idx_select$
-| stats sum(b) as bytes_used by pool poolsz
-| rename poolsz as bytes_poolsz
-| eval KB_used=round(bytes_used/1024, 4), MB_used=round(bytes_used/1024/1024, 4), GB_used=round(bytes_used/1024/1024/1024, 4)
-| eval KB_poolsz=round(bytes_poolsz/1024, 4) , MB_poolsz=round(bytes_poolsz/1024/1024, 4) , GB_poolsz=round(bytes_poolsz/1024/1024/1024, 4)
-| rename pool as Pool $unit$_used as "$unit$ license used" $unit$_poolsz as "$unit$ License Capacity"
-| fields Pool "$unit$ license used" "$unit$ License Capacity"
-| sort Pool</query>
+| stats sum(b) AS bytes_used BY pool poolsz
+| rename poolsz AS bytes_poolsz
+| foreach bytes_*  [ eval `process_bytes(&lt;&lt;FIELD&gt;&gt;, "$bytes_unit_abbreviated_label$")` ]
+| fields pool bytes_*
+| sort pool
+| rename pool AS Pool bytes_used AS "$bytes_unit_abbreviated_label$ License Used" bytes_poolsz AS "$bytes_unit_abbreviated_label$ License Capacity"</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -256,19 +248,17 @@
       </chart>
     </panel>
     <panel>
-      <title>Splunk License $unit$ Used by Index</title>
+      <title>Splunk License $bytes_unit_label$ Used by Index</title>
       <table>
         <search>
           <query>index=_internal source=*license_usage.log type=Usage pool=*
 | rename idx AS index
 | search $idx_select$
-| stats sum(b) as b by pool index
-| eval KB_used=round(b/1024, 4), MB_used=round(b/1024/1024, 4), GB_used=round(b/1024/1024/1024, 4)
-| rename b as bytes_used
-| addcoltotals $unit$_used labelfield=index label="TOTAL $unit$'s USED:"
-| rename index as Index pool as "License Pool" $unit$_used as "$unit$'s Used"
-| fields "License Pool" Index "$unit$'s Used"
-| sort - "$unit$'s Used"</query>
+| stats sum(b) as bytes_used by pool index
+| eval `process_bytes(bytes_used, "$bytes_unit_abbreviated_label$")`
+| fields index pool bytes_used
+| sort bytes_used
+| rename index as Index pool as "License Pool" bytes_used as "$bytes_unit_label$ Used"</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -277,10 +267,13 @@
         <option name="dataOverlayMode">none</option>
         <option name="drilldown">none</option>
         <option name="percentagesRow">false</option>
-        <option name="refresh.display">progressbar</option>
-        <option name="rowNumbers">false</option>
-        <option name="totalsRow">false</option>
+        <option name="rowNumbers">true</option>
+        <option name="totalsRow">true</option>
         <option name="wrap">true</option>
+        <format type="number" field="$bytes_unit_label$ Used">
+          <option name="unit">$bytes_unit_abbreviated_label$</option>
+          <option name="precision">$bytes_precision_table$</option>
+        </format>
       </table>
     </panel>
   </row>

--- a/criblvision/default/data/ui/views/cribl_thruput_introspection.xml
+++ b/criblvision/default/data/ui/views/cribl_thruput_introspection.xml
@@ -5,6 +5,15 @@
     <earliest>$time.earliest$</earliest>
     <latest>$time.latest$</latest>
   </search>
+  <search>
+    <done>
+      <set token="init_bytes_unit_abbreviated_label">$result.bytes_unit_abbreviated_label$</set>
+    </done>
+    <query>| makeresults | eval bytes_unit_abbreviated_label = upper(`set_bytes_unit`)
+    </query>
+    <earliest>-1m@m</earliest>
+    <latest>now</latest>
+  </search>
   <fieldset submitButton="true" autoRun="false">
     <input type="time" searchWhenChanged="true" token="time">
       <label>Time Range</label>
@@ -116,6 +125,26 @@
       </change>
       <prefix>span=</prefix>
     </input>
+    <input type="dropdown" token="bytes_unit" searchWhenChanged="true">
+      <label>Bytes Unit</label>
+      <default>$init_bytes_unit_abbreviated_label$</default>
+      <initialValue>$init_bytes_unit_abbreviated_label$</initialValue>
+      <fieldForLabel>unit</fieldForLabel>
+      <fieldForValue>abbreviated_unit</fieldForValue>
+      <search>
+        <query>| inputlookup bytes_units</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition>
+          <eval token="bytes_unit_abbreviated_label">value</eval>
+          <eval token="bytes_unit_label">label</eval>
+          <eval token="bytes_precision_single">if(lower(value) == "b", "0", "0.000")</eval>
+          <eval token="bytes_precision_table">if(lower(value) == "b", "0", "3")</eval>
+        </condition>
+      </change>
+    </input>
     <input type="link" token="how_to_use">
       <label>How to Use</label>
       <choice value="show">Show</choice>
@@ -174,7 +203,6 @@
     <panel>
       <chart>
         <title>Total Events Out</title>
-        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix("total.out_events")`) AS out_events WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ $output_token$ $mstats_span$ BY host group output fillnull_value=`set_unknown_worker_group_value`
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
@@ -184,9 +212,11 @@
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Event Count</option>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">zero</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.legend.placement">bottom</option>
         <option name="refresh.display">progressbar</option>
@@ -196,20 +226,22 @@
   <row>
     <panel>
       <chart>
-        <title>Total Bytes Out</title>
-        <search base="annotation_search" type="annotation"></search>
+        <title>Total $bytes_unit_label$ Out</title>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix("total.out_bytes")`) AS out_bytes  WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ $output_token$ $mstats_span$ BY host group output fillnull_value=`set_unknown_worker_group_value`
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
 | search $worker_group_event_filter$ $worker_group_metric_filter$
-| timechart sum("out_bytes") $timechart_span$ useother=false BY output WHERE max in top5
+| eval `process_bytes(out_bytes, "$bytes_unit_abbreviated_label$")`
+| timechart sum(out_bytes) $timechart_span$ useother=false BY output WHERE max in top5
 | fields - _span*</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisTitleY.text">Bytes</option>
+        <option name="charting.axisTitleY.text">$bytes_unit_label$ Out</option>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">zero</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.legend.placement">bottom</option>
         <option name="refresh.display">progressbar</option>
@@ -275,7 +307,6 @@
     <panel>
       <chart>
         <title>Total Events In</title>
-        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix("total.in_events")`) AS in_events WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ $input_token$ $mstats_span$ BY $splitby$ host group fillnull_value=`set_unknown_worker_group_value`
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
@@ -285,9 +316,11 @@
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Event Count</option>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">zero</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.legend.placement">bottom</option>
         <option name="refresh.display">progressbar</option>
@@ -298,7 +331,6 @@
     <panel>
       <chart>
         <title>CPU Percentage by Worker Process</title>
-        <search base="annotation_search" type="annotation"></search>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix("system.cpu_perc")`) AS cpu_perc WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $mstats_span$ BY host cribl_wp
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
@@ -308,9 +340,11 @@
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">CPU %</option>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">zero</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.legend.placement">bottom</option>
         <option name="refresh.display">progressbar</option>
@@ -320,20 +354,22 @@
   <row>
     <panel>
       <chart>
-        <title>Total Bytes In</title>
-        <search base="annotation_search" type="annotation"></search>
+        <title>Total $bytes_unit_label$ In</title>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix("total.in_bytes")`) AS in_bytes  WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ $input_token$ $mstats_span$ BY $splitby$ host group fillnull_value=`set_unknown_worker_group_value`
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
 | search $worker_group_event_filter$ $worker_group_metric_filter$
-| timechart sum("in_bytes") $timechart_span$ useother=false BY $splitby$ WHERE max in top$limit$
+| eval `process_bytes(in_bytes, "$bytes_unit_abbreviated_label$")`
+| timechart sum(in_bytes) $timechart_span$ useother=false BY $splitby$ WHERE max in top$limit$
 | fields - _span*</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisTitleY.text">Bytes</option>
+        <option name="charting.axisTitleY.text">$bytes_unit_label$ In</option>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">zero</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.legend.placement">bottom</option>
         <option name="refresh.display">progressbar</option>

--- a/criblvision/default/data/ui/views/health_check.xml
+++ b/criblvision/default/data/ui/views/health_check.xml
@@ -4,6 +4,15 @@
     <earliest>$time.earliest$</earliest>
     <latest>$time.latest$</latest>
   </search>
+  <search>
+    <done>
+      <set token="init_bytes_unit_abbreviated_label">$result.bytes_unit_abbreviated_label$</set>
+    </done>
+    <query>| makeresults | eval bytes_unit_abbreviated_label = upper(`set_bytes_unit`)
+    </query>
+    <earliest>-1m@m</earliest>
+    <latest>now</latest>
+  </search>
   <fieldset submitButton="true" autoRun="false">
     <input type="time" token="time" searchWhenChanged="true">
       <label>Time Range</label>
@@ -94,6 +103,26 @@
         </condition>
       </change>
     </input>
+    <input type="dropdown" token="bytes_unit" searchWhenChanged="true">
+      <label>Bytes Unit</label>
+      <default>$init_bytes_unit_abbreviated_label$</default>
+      <initialValue>$init_bytes_unit_abbreviated_label$</initialValue>
+      <fieldForLabel>unit</fieldForLabel>
+      <fieldForValue>abbreviated_unit</fieldForValue>
+      <search>
+        <query>| inputlookup bytes_units</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition>
+          <eval token="bytes_unit_abbreviated_label">value</eval>
+          <eval token="bytes_unit_label">label</eval>
+          <eval token="bytes_precision_single">if(lower(value) == "b", "0", "0.000")</eval>
+          <eval token="bytes_precision_table">if(lower(value) == "b", "0", "3")</eval>
+        </condition>
+      </change>
+    </input>
     <input type="link" token="how_to_use">
       <label>How to Use</label>
       <choice value="show">Show</choice>
@@ -177,6 +206,7 @@
           <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats"
 | bin _time span=1m
 | stats sum(mem.rss) AS memRss BY _time host instance_type worker_group
+| eval memRss = round(memRss * pow(1024, 2), 0), `process_bytes(memRss, "$bytes_unit_abbreviated_label$")`
 | stats avg(memRss) AS memRss</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -184,7 +214,7 @@
         <option name="colorBy">value</option>
         <option name="colorMode">none</option>
         <option name="drilldown">all</option>
-        <option name="numberPrecision">0.00</option>
+        <option name="numberPrecision">$bytes_precision_single$</option>
         <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
         <option name="rangeValues">[0,30,70,100]</option>
         <option name="refresh.display">progressbar</option>
@@ -195,7 +225,7 @@
         <option name="trellis.size">medium</option>
         <option name="trendColorInterpretation">standard</option>
         <option name="trendDisplayMode">absolute</option>
-        <option name="unit">MB</option>
+        <option name="unit">$bytes_unit_abbreviated_label$</option>
         <option name="unitPosition">after</option>
         <option name="useColors">0</option>
         <option name="useThousandSeparators">1</option>
@@ -210,13 +240,13 @@
     <panel>
       <title>CPU Perc (Avg) Breakdown by Host over Time</title>
       <chart>
-        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_cpu_perc$">
           <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats"
 | timechart avg(cpuPerc) BY host</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Avg CPU (%)</option>
         <option name="charting.chart">area</option>
@@ -260,17 +290,18 @@
     <panel>
       <title>Memory Usage (Avg) Breakdown by Host over Time</title>
       <chart>
-        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_mem_usage$">
           <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats"
 | bin _time span=1m 
 | stats sum(mem.rss) AS memRss BY _time host instance_type worker_group
+| eval memRss = round(memRss * pow(1024, 2), 0), `process_bytes(memRss, "$bytes_unit_abbreviated_label$")`
 | timechart avg(memRss) BY host</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisTitleY.text">Avg Memory Usage (MB)</option>
+        <option name="charting.axisTitleY.text">Avg Memory Usage ($bytes_unit_abbreviated_label$)</option>
         <option name="charting.chart">area</option>
         <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
@@ -285,7 +316,8 @@
           <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=server message="_raw stats"
 | bin _time span=1m 
 | stats sum(mem.rss) AS memRss BY _time host instance_type worker_group 
-| stats avg(memRss) AS memRss BY host instance_type worker_group 
+| stats avg(memRss) AS memRss BY host instance_type worker_group
+| eval memRss = round(memRss * pow(1024, 2), 0), `process_bytes(memRss, "$bytes_unit_abbreviated_label$")`
 | lookup cribl_stream_assets host OUTPUTNEW environment 
 | rename host AS Host environment AS Environment instance_type AS "Instance Type" worker_group AS "Worker Group" memRss AS "Memory Usage" 
 | `get_environment_hosts(Environment)`</query>
@@ -295,7 +327,8 @@
         <option name="drilldown">cell</option>
         <option name="refresh.display">progressbar</option>
         <format type="number" field="Memory Usage">
-          <option name="unit">MB</option>
+          <option name="precision">$bytes_precision_table$</option>
+          <option name="unit">$bytes_unit_abbreviated_label$</option>
         </format>
         <fields>["Host","Environment","Instance Type","Worker Group","Memory Usage"]</fields>
         <drilldown>
@@ -389,7 +422,8 @@
           <query>| mstats latest(`set_cribl_metrics_prefix("pq.queue_size")`) AS total_pq_size WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ BY host group fillnull_value=`set_unknown_worker_group_value`
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
 | search $worker_group_event_filter$ $worker_group_metric_filter$
-| stats sum(total_pq_size) AS total_pq_size</query>
+| stats sum(total_pq_size) AS total_pq_size
+| eval `process_bytes(total_pq_size, "$bytes_unit_abbreviated_label$")`</query>
           <earliest>-15m</earliest>
           <latest>now</latest>
           <sampleRatio>1</sampleRatio>
@@ -397,7 +431,7 @@
         <option name="colorBy">value</option>
         <option name="colorMode">none</option>
         <option name="drilldown">all</option>
-        <option name="numberPrecision">0</option>
+        <option name="numberPrecision">$bytes_precision_single$</option>
         <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
         <option name="rangeValues">[0,30,70,100]</option>
         <option name="refresh.display">progressbar</option>
@@ -408,7 +442,7 @@
         <option name="trellis.size">medium</option>
         <option name="trendColorInterpretation">standard</option>
         <option name="trendDisplayMode">absolute</option>
-        <option name="unit">B</option>
+        <option name="unit">$bytes_unit_abbreviated_label$</option>
         <option name="unitPosition">after</option>
         <option name="useColors">0</option>
         <option name="useThousandSeparators">1</option>
@@ -449,7 +483,6 @@
     <panel>
       <title>Unhealthy Sources over Time</title>
       <chart>
-        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_unhealthy_sources$">
           <query>| mstats max(`set_cribl_metrics_prefix("health.inputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ $unhealthy_sources$ span=auto BY host input group fillnull_value=`set_unknown_worker_group_value`
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
@@ -458,6 +491,7 @@
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisLabelsY.majorUnit">1</option>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Status</option>
@@ -512,7 +546,6 @@
     <panel>
       <title>Unhealthy Destinations over Time</title>
       <chart>
-        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_unhealthy_destinations$">
           <query>| mstats max(`set_cribl_metrics_prefix("health.outputs")`) AS health WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ $unhealthy_destinations$ span=auto BY host output group fillnull_value=`set_unknown_worker_group_value`
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
@@ -521,6 +554,7 @@
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisLabelsY.majorUnit">1</option>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Status</option>
@@ -594,17 +628,18 @@
     <panel id="total_pq_size_timeline">
       <title>PQ Size by Host (Last 15 Minutes)</title>
       <chart>
-        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_total_pq_size$">
           <query>| mstats sum(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_size WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ span=auto BY host group fillnull_value=`set_unknown_worker_group_value`
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
 | search $worker_group_event_filter$ $worker_group_metric_filter$
+| eval `process_bytes(pq_size, "$bytes_unit_abbreviated_label$")`
 | timechart sum(pq_size) BY host</query>
           <earliest>-15m</earliest>
           <latest>now</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisTitleY.text">PQ Size (B)</option>
+        <option name="charting.axisTitleY.text">PQ Size ($bytes_unit_abbreviated_label$)</option>
         <option name="charting.chart">line</option>
         <option name="charting.chart.nullValueMode">zero</option>
         <option name="charting.chart.showDataLabels">none</option>
@@ -620,6 +655,7 @@
           <query>| mstats latest(`set_cribl_metrics_prefix("pq.queue_size")`) AS total_pq_size WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ BY host group fillnull_value=`set_unknown_worker_group_value`
 | search $worker_group_metric_filter$ total_pq_size &gt; 0
 | lookup cribl_stream_assets host OUTPUTNEW environment instance_type
+| eval `process_bytes(total_pq_size, "$bytes_unit_abbreviated_label$")`
 | rename host AS Host environment AS Environment instance_type AS "Instance Type" group AS "Worker Group" total_pq_size AS "Total PQ Size"
 | `get_environment_hosts(Environment)`</query>
           <earliest>-15m</earliest>
@@ -628,8 +664,8 @@
         <option name="drilldown">cell</option>
         <option name="refresh.display">progressbar</option>
         <format type="number" field="Total PQ Size">
-          <option name="precision">0</option>
-          <option name="unit">B</option>
+          <option name="precision">$bytes_precision_table$</option>
+          <option name="unit">$bytes_unit_abbreviated_label$</option>
         </format>
         <fields>["Host","Environment","Instance Type","Worker Group","Total PQ Size"]</fields>
         <drilldown>
@@ -766,13 +802,13 @@
     <panel id="worker_process_reset_timeline">
       <title>Worker Process Restarts by Host over Time</title>
       <chart>
-        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_worker_process_restarts$">
           <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel=cribl* message="restarting worker process" 
 | timechart count BY host</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Worker Process Restarts</option>
         <option name="charting.chart">area</option>
@@ -802,7 +838,6 @@
     <panel id="backpressured_destinations_timeline">
       <title>Destinations with Backpressure over Time</title>
       <chart>
-        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_backpressured_destinations$">
           <query>| mstats max(`set_cribl_metrics_prefix("backpressure.outputs")`) AS back_pressured WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ BY host output group span=auto fillnull_value=`set_unknown_worker_group_value`
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
@@ -811,6 +846,7 @@
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Back Pressure</option>
         <option name="charting.axisY.minimumNumber">0</option>
@@ -851,7 +887,6 @@
     <panel id="blocked_destinations_timeline">
       <title>Blocked Destinations over Time</title>
       <chart>
-        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_blocked_destinations$">
           <query>| mstats max(`set_cribl_metrics_prefix("blocked.outputs")`) AS blocked WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ BY host output group span=auto fillnull_value=`set_unknown_worker_group_value`
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
@@ -860,6 +895,7 @@
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">Back Pressure</option>
         <option name="charting.axisY.abbreviation">none</option>
@@ -901,7 +937,6 @@
     <panel id="pq_engaged_timeline">
       <title>Sources/Destinations with PQ Engaged over Time (Last 15 Minutes)</title>
       <chart>
-        <search base="annotation_search" type="annotation"></search>
         <search depends="$show_pq_engaged$">
           <query>| mstats max(`set_cribl_metrics_prefix("pq.queue_size")`) AS pq_engaged WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ BY host input output group span=auto fillnull_value=`set_unknown_worker_group_value`
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
@@ -913,6 +948,7 @@
           <earliest>-15m</earliest>
           <latest>now</latest>
         </search>
+        <search base="annotation_search" type="annotation"></search>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleY.text">PQs Engaged</option>
         <option name="charting.chart">area</option>

--- a/criblvision/default/data/ui/views/persistent_queue_analytics.xml
+++ b/criblvision/default/data/ui/views/persistent_queue_analytics.xml
@@ -4,6 +4,15 @@
     <earliest>$time.earliest$</earliest>
     <latest>$time.latest$</latest>
   </search>
+  <search>
+    <done>
+      <set token="init_bytes_unit_abbreviated_label">$result.bytes_unit_abbreviated_label$</set>
+    </done>
+    <query>| makeresults | eval bytes_unit_abbreviated_label = upper(`set_bytes_unit`)
+    </query>
+    <earliest>-1m@m</earliest>
+    <latest>now</latest>
+  </search>
   <fieldset submitButton="true" autoRun="false">
     <input type="time" token="time" searchWhenChanged="true">
       <label>Time Range</label>
@@ -94,6 +103,26 @@
         </condition>
       </change>
     </input>
+    <input type="dropdown" token="bytes_unit" searchWhenChanged="true">
+      <label>Bytes Unit</label>
+      <default>$init_bytes_unit_abbreviated_label$</default>
+      <initialValue>$init_bytes_unit_abbreviated_label$</initialValue>
+      <fieldForLabel>unit</fieldForLabel>
+      <fieldForValue>abbreviated_unit</fieldForValue>
+      <search>
+        <query>| inputlookup bytes_units</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition>
+          <eval token="bytes_unit_abbreviated_label">value</eval>
+          <eval token="bytes_unit_label">label</eval>
+          <eval token="bytes_precision_single">if(lower(value) == "b", "0", "0.000")</eval>
+          <eval token="bytes_precision_table">if(lower(value) == "b", "0", "3")</eval>
+        </condition>
+      </change>
+    </input>
     <input type="link" token="how_to_use">
       <label>How to Use</label>
       <choice value="show">Show</choice>
@@ -155,13 +184,14 @@
       </single>
     </panel>
     <panel>
-      <title>Latest Persistent Queue Size</title>
+      <title>Latest Persistent Queue Size (in $bytes_unit_abbreviated_label$)</title>
       <single>
         <search>
           <query>| mstats latest(`set_cribl_metrics_prefix("pq.queue_size")`) as pq_size WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $worker_group_metric_pre_filter$ BY host input output group fillnull_value=`set_unknown_worker_group_value`
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
 | search $worker_group_event_filter$ $worker_group_metric_filter$
-| stats sum(pq_size) AS total_pq_size</query>
+| stats sum(pq_size) AS total_pq_size
+| eval `process_bytes(total_pq_size, "$bytes_unit_abbreviated_label$")`</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -169,7 +199,7 @@
         <option name="colorBy">value</option>
         <option name="colorMode">none</option>
         <option name="drilldown">none</option>
-        <option name="numberPrecision">0</option>
+        <option name="numberPrecision">$bytes_precision_single$</option>
         <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
         <option name="rangeValues">[0,30,70,100]</option>
         <option name="refresh.display">progressbar</option>
@@ -180,7 +210,7 @@
         <option name="trellis.size">medium</option>
         <option name="trendColorInterpretation">standard</option>
         <option name="trendDisplayMode">absolute</option>
-        <option name="unit">B</option>
+        <option name="unit">$bytes_unit_abbreviated_label$</option>
         <option name="unitPosition">after</option>
         <option name="useColors">0</option>
         <option name="useThousandSeparators">1</option>
@@ -198,7 +228,8 @@
 | rex field=pq "(?&lt;type&gt;[^:]+):(?&lt;technology&gt;[^:]+):(?&lt;pq&gt;.*)"
 | eval type = if(type == "input", "Source", "Destination")
 | stats sum(pq_size) AS pq_size BY type pq group
-| rename type AS Type pq AS "Persistent Queue" group AS "Worker Group" pq_size AS "PQ Size (B)"</query>
+| eval `process_bytes(pq_size, "$bytes_unit_abbreviated_label$")`
+| rename type AS Type pq AS "Persistent Queue" group AS "Worker Group" pq_size AS "PQ Size ($bytes_unit_abbreviated_label$)"</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -211,9 +242,9 @@
         <option name="rowNumbers">false</option>
         <option name="totalsRow">false</option>
         <option name="wrap">true</option>
-        <format type="number" field="PQ Size (B)">
-          <option name="precision">0</option>
-          <option name="unit">B</option>
+        <format type="number" field="PQ Size ($bytes_unit_abbreviated_label$)">
+          <option name="precision">$bytes_precision_table$</option>
+          <option name="unit">$bytes_unit_abbreviated_label$</option>
         </format>
       </table>
     </panel>
@@ -227,7 +258,7 @@
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
 | search $worker_group_event_filter$ $worker_group_metric_filter$
 | foreach *put [ eval &lt;&lt;FIELD&gt;&gt; = if(&lt;&lt;FIELD&gt;&gt; == `set_unknown_worker_group_value`, null(), "&lt;&lt;FIELD&gt;&gt;:".&lt;&lt;FIELD&gt;&gt;) ]
-| eval pq = coalesce(input, output)
+| eval pq = coalesce(input, output), `process_bytes(pq_size, "$bytes_unit_abbreviated_label$")`
 | timechart sum(pq_size) useother=false BY pq</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -238,7 +269,7 @@
         <option name="charting.axisLabelsX.majorLabelStyle.rotation">0</option>
         <option name="charting.axisTitleX.text">Time</option>
         <option name="charting.axisTitleX.visibility">visible</option>
-        <option name="charting.axisTitleY.text">PQ Size (B)</option>
+        <option name="charting.axisTitleY.text">PQ Size ($bytes_unit_abbreviated_label$)</option>
         <option name="charting.axisTitleY.visibility">visible</option>
         <option name="charting.axisTitleY2.visibility">visible</option>
         <option name="charting.axisX.abbreviation">none</option>

--- a/criblvision/default/data/ui/views/route_and_pipeline_reductions.xml
+++ b/criblvision/default/data/ui/views/route_and_pipeline_reductions.xml
@@ -191,7 +191,7 @@
       </search>
     </input>
     <input type="dropdown" token="bytes_unit" searchWhenChanged="true">
-      <label>Bytes Unit:</label>
+      <label>Bytes Unit</label>
       <default>$init_bytes_unit_abbreviated_label$</default>
       <initialValue>$init_bytes_unit_abbreviated_label$</initialValue>
       <fieldForLabel>unit</fieldForLabel>

--- a/criblvision/default/data/ui/views/sizingcalculator.xml
+++ b/criblvision/default/data/ui/views/sizingcalculator.xml
@@ -1,5 +1,14 @@
 <form theme="dark" version="1.1">
   <label>Cribl Stream Sizing Calculator</label>
+  <search>
+    <done>
+      <set token="init_bytes_unit_abbreviated_label">$result.bytes_unit_abbreviated_label$</set>
+    </done>
+    <query>| makeresults | eval bytes_unit_abbreviated_label = upper(`set_bytes_unit`)
+    </query>
+    <earliest>-1m@m</earliest>
+    <latest>now</latest>
+  </search>
   <fieldset submitButton="true" autoRun="false">
     <input type="time" token="time">
       <label>Time Range</label>
@@ -112,6 +121,26 @@
       <choice value="480">ARM64</choice>
       <default>200</default>
     </input>
+    <input type="dropdown" token="bytes_unit" searchWhenChanged="true">
+      <label>Bytes Unit</label>
+      <default>$init_bytes_unit_abbreviated_label$</default>
+      <initialValue>$init_bytes_unit_abbreviated_label$</initialValue>
+      <fieldForLabel>unit</fieldForLabel>
+      <fieldForValue>abbreviated_unit</fieldForValue>
+      <search>
+        <query>| inputlookup bytes_units</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition>
+          <eval token="bytes_unit_abbreviated_label">value</eval>
+          <eval token="bytes_unit_label">label</eval>
+          <eval token="bytes_precision_single">if(lower(value) == "b", "0", "0.000")</eval>
+          <eval token="bytes_precision_table">if(lower(value) == "b", "0", "3")</eval>
+        </condition>
+      </change>
+    </input>
     <input type="link" token="how_to_use">
       <label>How to Use</label>
       <choice value="show">Show</choice>
@@ -174,41 +203,44 @@
           <done>
             <set token="processingLimitPerCPU">$result.processingLimitPerCPU$</set>
           </done>
-          <query>| makeresults | eval processingLimitPerCPU=(($cpuType$ * $cpuSpeed$) / 3)</query>
+          <query>| makeresults 
+| eval processingLimitPerCPU = (($cpuType$ * $cpuSpeed$) / 3) * pow(1024, 3)
+| eval `process_bytes(processingLimitPerCPU, "$bytes_unit_abbreviated_label$")`</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
         <option name="drilldown">none</option>
         <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
         <option name="refresh.display">progressbar</option>
-        <option name="underLabel">GB/day</option>
+        <option name="underLabel">$bytes_unit_abbreviated_label$ / Day</option>
       </single>
     </panel>
     <panel>
       <title>Estimated Total Throughput per Worker Node</title>
       <single>
         <search>
-          <query>| makeresults | eval EstimatedLimit=($processingLimitPerCPU$ * $workerProcessCount$)</query>
+          <query>| makeresults 
+| eval EstimatedLimit = ($processingLimitPerCPU$ * $workerProcessCount$)</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
         <option name="drilldown">none</option>
         <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
         <option name="refresh.display">progressbar</option>
-        <option name="underLabel">GB/day</option>
+        <option name="underLabel">$bytes_unit_abbreviated_label$ / day</option>
       </single>
     </panel>
   </row>
   <row>
     <panel>
-      <title>Total Throughput (inBytes + outBytes) in GB</title>
+      <title>Total Throughput (inBytes + outBytes) in $bytes_unit_abbreviated_label$</title>
       <chart>
         <search>
           <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel="server" message="_raw stats"
 | bin span=1d _time
 | stats sum(inBytes) AS inBytes sum(outBytes) AS outBytes by _time
-| eval totalGB=round((('inBytes' + 'outBytes') / 1024 / 1024 / 1024), 0)
-| timechart span=1d max(totalGB) AS "Total Throughput (GB)"</query>
+| eval total = inBytes + outBytes, `process_bytes(total, "$bytes_unit_abbreviated_label$")`
+| timechart span=1d max(total) AS "Total Throughput ($bytes_unit_abbreviated_label$)"</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
@@ -227,9 +259,8 @@
           <query>`set_cribl_internal_log_index` `set_cribl_log_sourcetype` $environment_filter$ $host_filter$ $worker_group_event_filter$ channel="server" message="_raw stats"
 | bin span=1d _time
 | stats sum(inBytes) AS inBytes sum(outBytes) AS outBytes by _time
-| eval inGB=round(('inBytes' / 1024 / 1024 / 1024), 0)
-| eval outGB=round(('outBytes' / 1024 / 1024 / 1024), 0)
-| eval calculation=(round(((('inGB' + 'outGB') * 1024) / $processingLimitPerCPU$), 0) + 1)
+| eval total = inBytes + outBytes, `process_bytes(total, "$bytes_unit_abbreviated_label$")`
+| eval calculation=(round((total / $processingLimitPerCPU$), 0) + 1)
 | timechart span=1d max(calculation) AS "Estimated Worker Processes Required"</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
@@ -252,31 +283,30 @@
 | bin span=1d _time
 | stats sum(inBytes) AS inBytes sum(outBytes) AS outBytes by _time
 | eval date = strftime(_time, "%Y-%m-%d")
-| eval inGB = round((inBytes / 1024 / 1024 / 1024), 0)
-| eval outGB = round((outBytes / 1024 / 1024 / 1024), 0)
-| eval totalGB = (inGB + outGB)
-| eval wpRequired = (round(('totalGB' / $processingLimitPerCPU$), 0) + 1)
-| table date inGB outGB totalGB wpRequired
-| rename date AS Date inGB AS "GB In" outGB AS "GB Out" totalGB AS "Total GB" wpRequired AS "Estimated Worker Processes Required"</query>
+| foreach *Bytes [ eval `process_bytes(&lt;&lt;FIELD&gt;&gt;, "$bytes_unit_abbreviated_label$")` ]
+| eval totalBytes = inBytes + outBytes
+| eval wpRequired = (round((totalBytes / $processingLimitPerCPU$), 0) + 1)
+| table date inBytes outBytes totalBytes wpRequired
+| rename date AS Date inBytes AS "$bytes_unit_abbreviated_label$ In" outBytes AS "$bytes_unit_abbreviated_label$ Out" totalBytes AS "Total $bytes_unit_abbreviated_label$" wpRequired AS "Estimated Worker Processes Required"</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
         <option name="drilldown">none</option>
         <option name="refresh.display">progressbar</option>
-        <format type="number" field="GB In">
-          <option name="precision">0</option>
-          <option name="unit">GB</option>
-        </format>
-        <format type="number" field="GB Out">
-          <option name="precision">0</option>
-          <option name="unit">GB</option>
-        </format>
-        <format type="number" field="Total GB">
-          <option name="precision">0</option>
-          <option name="unit">GB</option>
-        </format>
         <format type="number" field="Estimated Worker Processes Required">
           <option name="precision">0</option>
+        </format>
+        <format type="number" field="$bytes_unit_abbreviated_label$ In">
+          <option name="precision">$bytes_precision_table$</option>
+          <option name="unit">$bytes_unit_abbreviated_label$</option>
+        </format>
+        <format type="number" field="$bytes_unit_abbreviated_label$ Out">
+          <option name="precision">$bytes_precision_table$</option>
+          <option name="unit">$bytes_unit_abbreviated_label$</option>
+        </format>
+        <format type="number" field="Total $bytes_unit_abbreviated_label$">
+          <option name="precision">$bytes_precision_table$</option>
+          <option name="unit">$bytes_unit_abbreviated_label$</option>
         </format>
       </table>
     </panel>

--- a/criblvision/default/data/ui/views/sources_and_destinations_overview.xml
+++ b/criblvision/default/data/ui/views/sources_and_destinations_overview.xml
@@ -15,6 +15,15 @@
     <earliest>$time.earliest$</earliest>
     <latest>$time.latest$</latest>
   </search>
+  <search>
+    <done>
+      <set token="init_bytes_unit_abbreviated_label">$result.bytes_unit_abbreviated_label$</set>
+    </done>
+    <query>| makeresults | eval bytes_unit_abbreviated_label = upper(`set_bytes_unit`)
+    </query>
+    <earliest>-1m@m</earliest>
+    <latest>now</latest>
+  </search>
   <fieldset submitButton="true" autoRun="false">
     <input type="time" token="time" searchWhenChanged="true">
       <label>Time Range</label>
@@ -136,6 +145,26 @@
         <eval token="full_selected">if($label$ == "All" OR isnull($label$), "*", $label$)</eval>
       </change>
     </input>
+    <input type="dropdown" token="bytes_unit" searchWhenChanged="true">
+      <label>Bytes Unit</label>
+      <default>$init_bytes_unit_abbreviated_label$</default>
+      <initialValue>$init_bytes_unit_abbreviated_label$</initialValue>
+      <fieldForLabel>unit</fieldForLabel>
+      <fieldForValue>abbreviated_unit</fieldForValue>
+      <search>
+        <query>| inputlookup bytes_units</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition>
+          <eval token="bytes_unit_abbreviated_label">value</eval>
+          <eval token="bytes_unit_label">label</eval>
+          <eval token="bytes_precision_single">if(lower(value) == "b", "0", "0.000")</eval>
+          <eval token="bytes_precision_table">if(lower(value) == "b", "0", "3")</eval>
+        </condition>
+      </change>
+    </input>
     <input type="link" token="how_to_use">
       <label>How to Use</label>
       <choice value="show">Show</choice>
@@ -164,19 +193,21 @@
   <row>
     <panel>
       <single>
-        <title>Total Bytes $type_printable$</title>
+        <title>Total $bytes_unit_label$ $type_printable$</title>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix(total.$type$_bytes)`) AS $type$_bytes WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $type$put="$full_selected$" $worker_group_metric_pre_filter$ BY host group fillnull_value=`set_unknown_worker_group_value`
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
 | search $worker_group_event_filter$ $worker_group_metric_filter$
-| stats sum($type$_bytes) AS $type$_bytes</query>
+| stats sum($type$_bytes) AS $type$_bytes
+| eval `process_bytes($type$_bytes, "$bytes_unit_abbreviated_label$")`</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
         <option name="drilldown">none</option>
+        <option name="numberPrecision">$bytes_precision_single$</option>
         <option name="rangeColors">["0x53a051","0x0877a6","0xf8be34","0xf1813f","0xdc4e41"]</option>
         <option name="refresh.display">progressbar</option>
-        <option name="unit">B</option>
+        <option name="unit">$bytes_unit_abbreviated_label$</option>
       </single>
     </panel>
     <panel>
@@ -198,18 +229,19 @@
   <row>
     <panel>
       <chart>
-        <title>Total Bytes $type_printable$ over Time</title>
+        <title>Total $bytes_unit_label$ $type_printable$ over Time</title>
         <search base="annotation_search" type="annotation"></search>
         <search>
           <query>| mstats sum(`set_cribl_metrics_prefix(total.$type$_bytes)`) AS $type$_bytes WHERE `set_cribl_metrics_index` $environment_filter$ $host_filter$ $type$put="$full_selected$" $worker_group_metric_pre_filter$ span=auto BY host group $type$put fillnull_value=`set_unknown_worker_group_value`
 | lookup cribl_stream_assets host OUTPUTNEW instance_type worker_group
 | search $worker_group_event_filter$ $worker_group_metric_filter$
+| eval `process_bytes($type$_bytes, "$bytes_unit_abbreviated_label$")`
 | timechart sum($type$_bytes) BY $type$put</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
         <option name="charting.axisTitleX.text">Time</option>
-        <option name="charting.axisTitleY.text">Bytes</option>
+        <option name="charting.axisTitleY.text">$bytes_unit_label$</option>
         <option name="charting.chart">area</option>
         <option name="charting.chart.nullValueMode">zero</option>
         <option name="charting.chart.stackMode">stacked</option>

--- a/criblvision/default/data/ui/views/splunk_destination_troubleshooting.xml
+++ b/criblvision/default/data/ui/views/splunk_destination_troubleshooting.xml
@@ -12,6 +12,15 @@
     <earliest>$time.earliest$</earliest>
     <latest>$time.latest$</latest>
   </search>
+  <search>
+    <done>
+      <set token="init_bytes_unit_abbreviated_label">$result.bytes_unit_abbreviated_label$</set>
+    </done>
+    <query>| makeresults | eval bytes_unit_abbreviated_label = upper(`set_bytes_unit`)
+    </query>
+    <earliest>-1m@m</earliest>
+    <latest>now</latest>
+  </search>
   <fieldset submitButton="true" autoRun="false">
     <input type="time" token="time" searchWhenChanged="true">
       <label>Time Range</label>
@@ -119,6 +128,26 @@
       <choice value="[ | mstats sum(`set_cribl_metrics_prefix(health.outputs)`) WHERE `set_cribl_metrics_index` output IN (splunk:*, splunk_lb:*) BY output | rex field=output &quot;[^:]+:(?&lt;channel&gt;[^:]+)&quot; | eval channel = &quot;output:&quot;.channel | table channel ]">All</choice>
       <initialValue>[ | mstats sum(`set_cribl_metrics_prefix(health.outputs)`) WHERE `set_cribl_metrics_index` output IN (splunk:*, splunk_lb:*) BY output | rex field=output "[^:]+:(?&lt;channel&gt;[^:]+)" | eval channel = "output:".channel | table channel ]</initialValue>
     </input>
+    <input type="dropdown" token="bytes_unit" searchWhenChanged="true">
+      <label>Bytes Unit</label>
+      <default>$init_bytes_unit_abbreviated_label$</default>
+      <initialValue>$init_bytes_unit_abbreviated_label$</initialValue>
+      <fieldForLabel>unit</fieldForLabel>
+      <fieldForValue>abbreviated_unit</fieldForValue>
+      <search>
+        <query>| inputlookup bytes_units</query>
+        <earliest>-1m@m</earliest>
+        <latest>now</latest>
+      </search>
+      <change>
+        <condition>
+          <eval token="bytes_unit_abbreviated_label">value</eval>
+          <eval token="bytes_unit_label">label</eval>
+          <eval token="bytes_precision_single">if(lower(value) == "b", "0", "0.000")</eval>
+          <eval token="bytes_precision_table">if(lower(value) == "b", "0", "3")</eval>
+        </condition>
+      </change>
+    </input>
     <input type="link" token="how_to_use">
       <label>How to Use</label>
       <choice value="show">Show</choice>
@@ -218,8 +247,9 @@
         <search>
           <query>index=_internal sourcetype=splunkd component=SQSSmartbusInputWorker log_level=WARN "Invalid subsecond field"
 | rex "bytesRemaining\=(?&lt;bytes_remaining&gt;\d+)"
-| stats count AS "Number of Events" sum(bytes_remaining) AS "Bytes Remaining"
-| fillnull value=0 "Bytes Remaining"</query>
+| eval `process_bytes(bytes_remaining, "$bytes_unit_abbreviated_label$")`
+| stats count AS "Number of Events" sum(bytes_remaining) AS "$bytes_unit_label$ Remaining"
+| fillnull value=0 "$bytes_unit_label$ Remaining"</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>
         </search>
@@ -228,9 +258,9 @@
         <format type="number" field="Subsecond Error Count">
           <option name="precision">0</option>
         </format>
-        <format type="number" field="Bytes Remaining">
-          <option name="precision">0</option>
-          <option name="unit">B</option>
+        <format type="number" field="$bytes_unit_label$ Remaining">
+          <option name="precision">$bytes_precision_table$</option>
+          <option name="unit">$bytes_unit_abbreviated_label$</option>
         </format>
         <format type="number" field="Number of Events">
           <option name="precision">0</option>


### PR DESCRIPTION
Updated the following dashboards to include a bytes unit dropdown filter:
- Cribl Stream License Metrics
- Cribl Stream Sizing Calculator
- Cribl Thruput Introspection
- Health Check
- Persistent Queue Analytics
- Sources/Destinations Overview
- Splunk S2S Destination Troubleshooting